### PR TITLE
Initial job and pool template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+out
+
 # Logs
 logs
 *.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm"
+        },
+        {
+            "name": "Launch Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+    "version": "0.1.0",
+
+    // we want to run npm
+    "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
+
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
+
+    // The tsc compiler is started in watching mode
+    "isBackground": true,
+
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This isn't yet published in the VS Code marketplace.  To run it yourself:
 * Open the folder in VS Code (`code .`).
 * Hit F5 to run the extension in the Extension Development Host.
 
-The extension uses VS Code 1.13 features so you will need that version or above.
+The extension uses VS Code 1.13 (May 2017) features so you will need that version or above.
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is early-stage work in progress.  The happy paths should work okay, but the
 
 This extension depends on the [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/overview) and the [Azure Batch CLI extensions](https://github.com/Azure/azure-batch-cli-extensions).  Before running this VS Code extension, you must install both of these, *and* must log in to Azure (`az login`) and to a Batch account (`az batch account login`).  (At the moment, the VS Code extension doesn't provide any interactive support for installation or login, though you can run the login commands through the VS Code Terminal window.  If you install the CLI but not the Batch extensions, you may get weird errors!)
 
+The extension includes a custom explorer pane and therefore requires VS Code 1.13 or above.
+
 # Commands
 
 All commands are in the 'Azure' category.
@@ -17,6 +19,12 @@ All commands are in the 'Azure' category.
 * **Azure: Create Batch Job:** Creates an Azure Batch job from the job template or job JSON in the active tab.  If the active tab is a template, the command prompts for a value for each template parameter.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).
 
 * **Azure: Create Batch Pool:** Similar to Create Batch Job but creates a pool from a template or JSON.
+
+* **Azure: Create Batch Template from Job:** Prompts for a job in the Azure Batch account, and creates a Batch Extensions template based on that job.  You can then use the **Convert to Parameter** command to parameterise aspects of of the job.
+
+* **Azure: Create Batch Template from Pool:** Similar to Create Batch Template from Job but creates a pool template.
+
+* **Azure: Convert to Batch Template Parameter:** Applies to job or pool templates.  Converts the selected property to a template parameter - that is, it adds a declaration to the parameters section of the template, and sets the value of the property to be a reference to that newly created parameter.  (Of course you can then edit the parameter to change the name, description, etc.)
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,31 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension for working wit
 
 This is early-stage work in progress.  The happy paths should work okay, but the error paths haven't really been tested, and are likely to produce mediocre error messages at best!  And it hasn't yet been tested at all on Mac or Linux.  Please do raise issues for anything which is missing (plenty of that!), broken or unpolished.
 
+## Running the Extension
+
+This isn't yet published in the VS Code marketplace.  To run it yourself:
+
+* Clone the git repo.
+* Run `npm install` in the working copy root.
+* Open the folder in VS Code (`code .`).
+* Hit F5 to run the extension in the Extension Development Host.
+
+The extension uses VS Code 1.13 features so you will need that version or above.
+
 # Prerequisites
 
 This extension depends on the [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/overview) and the [Azure Batch CLI extensions](https://github.com/Azure/azure-batch-cli-extensions).  Before running this VS Code extension, you must install both of these, *and* must log in to Azure (`az login`) and to a Batch account (`az batch account login`).  (At the moment, the VS Code extension doesn't provide any interactive support for installation or login, though you can run the login commands through the VS Code Terminal window.  If you install the CLI but not the Batch extensions, you may get weird errors!)
 
-The extension includes a custom explorer pane and therefore requires VS Code 1.13 or above.
+**Important:** The 'convenient' ways of installing Azure CLI 2.0 (e.g. the Windows MSI) _will not allow you to install the Batch Extensions_.  You need the `az component update` command to install the extensions.  You _should_ be able to use `pip install azure-cli` to install the CLI with component update support (if it doesn't work, please let the Azure CLI folks know).
+
+# Features
+
+* Commands for working with Azure Batch job templates and pool templates (see below)
+* Snippets and auto-completion for common template elements and parameters
+  * Type `batch` in a JSON file to see available snippets
+* Template diagnostics
+  * Warning squiggles when a template references an undeclared parameter (current status: wonky)
+* Custom explorer pane displaying Azure Batch jobs and pools
 
 # Commands
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This extension depends on the [Azure CLI 2.0](https://docs.microsoft.com/en-us/c
 
 All commands are in the 'Azure' category.
 
-* **Azure: Create Batch Job:** Creates an Azure Batch job from the job template or job JSON in the active tab.  If the active tab is a template, the command prompts for a value for each template parameter.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).
+* **Azure: Create Batch Job:** Creates an Azure Batch job from the job template or job JSON in the active tab.  If the active tab is a template, the command prompts for a value for each template parameter.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).  Refer to [the documentation for the template and parameter file formats](https://github.com/Azure/azure-batch-cli-extensions/blob/master/doc/templates.md).
 
 * **Azure: Create Batch Pool:** Similar to Create Batch Job but creates a pool from a template or JSON.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# Azure Batch Tools for Visual Studio Code
+
+A [Visual Studio Code](https://code.visualstudio.com/) extension for working with [Azure Batch](https://azure.microsoft.com/services/batch/).
+
+## Status
+
+This is early-stage work in progress.  The happy paths should work okay, but the error paths haven't really been tested, and are likely to produce mediocre error messages at best!  And it hasn't yet been tested at all on Mac or Linux.  Please do raise issues for anything which is missing (plenty of that!), broken or unpolished.
+
+# Prerequisites
+
+This extension depends on the [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/overview) and the [Azure Batch CLI extensions](https://github.com/Azure/azure-batch-cli-extensions).  Before running this VS Code extension, you must install both of these, *and* must log in to Azure (`az login`) and to a Batch account (`az batch account login`).  (At the moment, the VS Code extension doesn't provide any interactive support for installation or login, though you can run the login commands through the VS Code Terminal window.  If you install the CLI but not the Batch extensions, you may get weird errors!)
+
+# Commands
+
+All commands are in the 'Azure' category.
+
+* **Azure: Create Batch Job:** Creates an Azure Batch job from the job template in the active tab.  (It doesn't yet support plain old job JSON.)  If the template has parameters, it will prompt for the values to use for this job.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).
+
+* **Azure: Create Batch Pool:** Similar to Create Batch Job but creates a pool from a template.  (Again, plain pool JSON is not yet supported.)
+
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This extension depends on the [Azure CLI 2.0](https://docs.microsoft.com/en-us/c
 
 All commands are in the 'Azure' category.
 
-* **Azure: Create Batch Job:** Creates an Azure Batch job from the job template in the active tab.  (It doesn't yet support plain old job JSON.)  If the template has parameters, it will prompt for the values to use for this job.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).
+* **Azure: Create Batch Job:** Creates an Azure Batch job from the job template or job JSON in the active tab.  If the active tab is a template, the command prompts for a value for each template parameter.  If there is a parameters file in the same directory (named the same as the job template, but with the extension `.parameters.json`), then it will use any values in this file (but will prompt for any values not given in the file).
 
-* **Azure: Create Batch Pool:** Similar to Create Batch Job but creates a pool from a template.  (Again, plain pool JSON is not yet supported.)
+* **Azure: Create Batch Pool:** Similar to Create Batch Job but creates a pool from a template or JSON.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "activationEvents": [
     "onCommand:azure.batch.createJob",
-    "onCommand:azure.batch.createPool"
+    "onCommand:azure.batch.createPool",
+    "onCommand:azure.batch.createTemplateFromJob"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -34,6 +35,11 @@
       {
         "command": "azure.batch.createPool",
         "title": "Create Batch Pool",
+        "category": "Azure"
+      },
+      {
+        "command": "azure.batch.createTemplateFromJob",
+        "title": "Create Batch Template from Job",
         "category": "Azure"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "onCommand:azure.batch.createTemplateFromJob",
     "onCommand:azure.batch.createTemplateFromPool",
     "onCommand:azure.batch.convertToParameter",
-    "onView:azure.batch.explorer"
+    "onView:azure.batch.explorer",
+    "onLanguage:json"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "publisher": "itowlson",
   "engines": {
-    "vscode": "^1.12.0"
+    "vscode": "^1.13.0"
   },
  "repository": {
     "type": "git",
@@ -24,7 +24,8 @@
     "onCommand:azure.batch.createPool",
     "onCommand:azure.batch.createTemplateFromJob",
     "onCommand:azure.batch.createTemplateFromPool",
-    "onCommand:azure.batch.convertToParameter"
+    "onCommand:azure.batch.convertToParameter",
+    "onView:azure.batch.explorer"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -53,14 +54,53 @@
         "command": "azure.batch.convertToParameter",
         "title": "Convert to Batch Template Parameter",
         "category": "Azure"
-      }
+      },
+			{
+				"command": "azure.batch.get",
+				"title": "Get"
+			},
+			{
+				"command": "azure.batch.getAsTemplate",
+				"title": "Get as Template"
+			},
+			{
+				"command": "azure.batch.refresh",
+				"title": "Refresh"
+			}
     ],
     "snippets": [
       {
         "language": "json",
         "path": "./snippet/job.json"
       }
-    ]
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "azure.batch.explorer",
+          "name": "Azure Batch"
+        }
+      ]
+    },
+    "menus":{
+      "view/title" : [
+        {
+          "command" : "azure.batch.refresh",
+          "when": "view == azure.batch.explorer",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "azure.batch.get",
+          "when": "view == azure.batch.explorer && viewItem == azure.batch.resource"
+        },
+        {
+          "command": "azure.batch.getAsTemplate",
+          "when": "view == azure.batch.explorer && viewItem == azure.batch.resource"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "onCommand:azure.batch.createJob",
     "onCommand:azure.batch.createPool",
     "onCommand:azure.batch.createTemplateFromJob",
+    "onCommand:azure.batch.createTemplateFromPool",
     "onCommand:azure.batch.convertToParameter"
   ],
   "main": "./out/src/extension",
@@ -41,6 +42,11 @@
       {
         "command": "azure.batch.createTemplateFromJob",
         "title": "Create Batch Template from Job",
+        "category": "Azure"
+      },
+      {
+        "command": "azure.batch.createTemplateFromPool",
+        "title": "Create Batch Template from Pool",
         "category": "Azure"
       },
       {

--- a/package.json
+++ b/package.json
@@ -113,12 +113,15 @@
     "@types/node": "^6.0.40",
     "@types/shelljs": "^0.7.1",
     "@types/tmp": "0.0.33",
+    "@types/moment-duration-format": "^1.3.5",
     "mocha": "^2.3.3",
     "typescript": "^2.0.3",
     "vscode": "^1.0.0"
   },
   "dependencies": {
     "shelljs": "^0.7.7",
-    "tmp": "^0.0.31"
+    "tmp": "^0.0.31",
+    "moment": "^2.15.2",
+    "moment-duration-format": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "activationEvents": [
     "onCommand:azure.batch.createJob",
     "onCommand:azure.batch.createPool",
-    "onCommand:azure.batch.createTemplateFromJob"
+    "onCommand:azure.batch.createTemplateFromJob",
+    "onCommand:azure.batch.convertToParameter"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -40,6 +41,11 @@
       {
         "command": "azure.batch.createTemplateFromJob",
         "title": "Create Batch Template from Job",
+        "category": "Azure"
+      },
+      {
+        "command": "azure.batch.convertToParameter",
+        "title": "Convert to Batch Template Parameter",
         "category": "Azure"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "vscode-azure-batch-tools",
+  "displayName": "Azure Batch Tools for Visual Studio Code",
+  "description": "Commands for authoring and deploying Azure Batch resources",
+  "version": "0.0.1",
+  "publisher": "itowlson",
+  "engines": {
+    "vscode": "^1.12.0"
+  },
+ "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/vscode-azure-batch-tools.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Azure/vscode-azure-batch-tools/issues"
+  },
+  "keywords": [
+    "azure",
+    "batch",
+    "cloud"
+  ],
+  "activationEvents": [
+    "onCommand:azure.batch.createJob",
+    "onCommand:azure.batch.createPool"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "azure.batch.createJob",
+        "title": "Create Batch Job",
+        "category": "Azure"
+      },
+      {
+        "command": "azure.batch.createPool",
+        "title": "Create Batch Pool",
+        "category": "Azure"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.32",
+    "@types/node": "^6.0.40",
+    "@types/shelljs": "^0.7.1",
+    "@types/tmp": "0.0.33",
+    "mocha": "^2.3.3",
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0"
+  },
+  "dependencies": {
+    "shelljs": "^0.7.7",
+    "tmp": "^0.0.31"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
       {
         "language": "json",
         "path": "./snippet/job.json"
+      },
+      {
+        "language": "json",
+        "path": "./snippet/template.json"
       }
     ],
     "views": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
         "title": "Create Batch Pool",
         "category": "Azure"
       }
+    ],
+    "snippets": [
+      {
+        "language": "json",
+        "path": "./snippet/job.json"
+      }
     ]
   },
   "scripts": {

--- a/snippet/job.json
+++ b/snippet/job.json
@@ -1,6 +1,6 @@
 {
     "Azure Batch Application Template": {
-        "prefix": "batch.apptemplate",
+        "prefix": "batch.app-template",
         "body": [
             "{",
             "\t\"parameters\": {",
@@ -11,7 +11,7 @@
         "description": "An application template for Azure Batch jobs"
     },
     "Azure Batch Task Per File Task Factory": {
-        "prefix": "batch.taskperfile",
+        "prefix": "batch.task-per-file",
         "body": [
             "\"taskFactory\": {",
             "\t\"type\": \"taskPerFile\",",
@@ -28,7 +28,7 @@
         "description": "A task-per-file task factory for Azure Batch jobs"
     },
     "Azure Batch Parametric Sweep Task Factory": {
-        "prefix": "batch.parametricsweep",
+        "prefix": "batch.parametric-sweep",
         "body": [
             "\"taskFactory\": {",
             "\t\"type\": \"parametricSweep\",",
@@ -48,7 +48,7 @@
         "description": "A parametric sweep task factory for Azure Batch jobs"
     },
     "Azure Batch Task Collection Task Factory": {
-        "prefix": "batch.taskcollection",
+        "prefix": "batch.task-collection",
         "body": [
             "\"taskFactory\": {",
             "\t\"tasks\": [",

--- a/snippet/job.json
+++ b/snippet/job.json
@@ -1,0 +1,59 @@
+{
+    "Azure Batch Application Template": {
+        "prefix": "batch.apptemplate",
+        "body": [
+            "{",
+            "\t\"parameters\": {",
+            "\t},",
+            "\t\"onAllTasksComplete\": \"terminateJob\"",
+            "}"
+        ],
+        "description": "An application template for Azure Batch jobs"
+    },
+    "Azure Batch Task Per File Task Factory": {
+        "prefix": "batch.taskperfile",
+        "body": [
+            "\"taskFactory\": {",
+            "\t\"type\": \"taskPerFile\",",
+            "\t\"source\": {",
+            "\t\t\"fileGroup\": \"${1:fileGroup}\"",
+            "\t},",
+            "\t\"repeatTask\": {",
+            "\t\t\"commandLine\": \"${2:commandLine}\",",
+            "\t\t\"resourceFiles\": [],",
+            "\t\t\"outputFiles\": []",
+            "\t}",
+            "}"
+        ],
+        "description": "A task-per-file task factory for Azure Batch jobs"
+    },
+    "Azure Batch Parametric Sweep Task Factory": {
+        "prefix": "batch.parametricsweep",
+        "body": [
+            "\"taskFactory\": {",
+            "\t\"type\": \"parametricSweep\",",
+            "\t\"parameterSets\": [ {",
+            "\t\t\"start\": \"${1:start}\",",
+            "\t\t\"end\": \"${2:end}\",",
+            "\t\t\"step\": 1",
+            "\t} ],",
+            "\t\"repeatTask\": {",
+            "\t\t\"commandLine\": \"${3:commandLine}\",",
+            "\t\t\"resourceFiles\": [],",
+            "\t\t\"outputFiles\": []",
+            "\t}",
+            "}"
+        ],
+        "description": "A parametric sweep task factory for Azure Batch jobs"
+    },
+    "Azure Batch Task Collection Task Factory": {
+        "prefix": "batch.taskcollection",
+        "body": [
+            "\"taskFactory\": {",
+            "\t\"tasks\": []",
+            "\t}",
+            "}"
+        ],
+        "description": "A task collection task factory for Azure Batch jobs"
+    }
+}

--- a/snippet/job.json
+++ b/snippet/job.json
@@ -39,7 +39,8 @@
             "\t} ],",
             "\t\"repeatTask\": {",
             "\t\t\"commandLine\": \"${3:commandLine}\",",
-            "\t\t\"resourceFiles\": [],",
+            "\t\t\"resourceFiles\": [",
+            "\t\t],",
             "\t\t\"outputFiles\": []",
             "\t}",
             "}"
@@ -50,7 +51,8 @@
         "prefix": "batch.taskcollection",
         "body": [
             "\"taskFactory\": {",
-            "\t\"tasks\": []",
+            "\t\"tasks\": [",
+            "\t]",
             "\t}",
             "}"
         ],

--- a/snippet/template.json
+++ b/snippet/template.json
@@ -17,7 +17,7 @@
         "description": "An Azure Batch resource template"
     },
     "Azure Batch Template Parameter": {
-        "prefix": "batch.parameter",
+        "prefix": "batch.parameter-declaration",
         "body": [
             "\"${1:name}\": {",
             "\t\"type\": \"${2:string}\",",
@@ -26,6 +26,6 @@
             "\t}",
             "}"
         ],
-        "description": "A parameter for an Azure Batch template"
+        "description": "Declares a parameter for an Azure Batch template"
     }
 }

--- a/snippet/template.json
+++ b/snippet/template.json
@@ -1,0 +1,31 @@
+{
+    "Azure Batch Template": {
+        "prefix": "batch.template",
+        "body": [
+            "{",
+            "\t\"parameters\": {$0",
+            "\t},",
+            "\t\"${1:job}\": {",
+            "\t\t\"type\": \"Microsoft.Batch/batchAccounts/${1:job}s\",",
+            "\t\t\"apiVersion\": \"2017-05-01\",",
+            "\t\t\"properties\": {",
+            "\t\t\t\"id\": \"${2:id}\"",
+            "\t\t}",
+            "\t},",
+            "}"
+        ],
+        "description": "An Azure Batch resource template"
+    },
+    "Azure Batch Template Parameter": {
+        "prefix": "batch.parameter",
+        "body": [
+            "\"${1:name}\": {",
+            "\t\"type\": \"${2:string}\",",
+            "\t\"metadata\": {",
+            "\t\t\"description\": \"$3\"",
+            "\t}",
+            "}"
+        ],
+        "description": "A parameter for an Azure Batch template"
+    }
+}

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import * as batch from './batch';
 import * as shell from './shell';
 
+export const UriScheme : string = 'ab';
+
 export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTreeNode>, vscode.TextDocumentContentProvider {
     getTreeItem(abtn : AzureBatchTreeNode) : vscode.TreeItem {
         const collapsibleState = abtn.kind == 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
@@ -65,11 +67,11 @@ type AbtnKind = 'root' | 'resource';
 class RootNode implements AzureBatchTreeNode {
     constructor(readonly text : string, readonly resourceType : batch.BatchResourceType) { }
     readonly kind : AbtnKind = 'root';
-    readonly uri : vscode.Uri = vscode.Uri.parse('ab://');
+    readonly uri : vscode.Uri = vscode.Uri.parse(`${UriScheme}://`);
 }
 
 class ResourceNode implements AzureBatchTreeNode {
     constructor(readonly text : string, readonly resourceType : batch.BatchResourceType, readonly resource : any) { }
     readonly kind : AbtnKind = 'resource';
-    readonly uri : vscode.Uri = vscode.Uri.parse(`ab://${this.resourceType}/${this.resource.id}.json`)
+    readonly uri : vscode.Uri = vscode.Uri.parse(`${UriScheme}://${this.resourceType}/${this.resource.id}.json`)
 }

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+import * as batch from './batch';
+import * as shell from './shell';
+
+export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTreeNode> {
+    getTreeItem(abtn : AzureBatchTreeNode) : vscode.TreeItem {
+        const collapsibleState = abtn.kind == 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
+        let item = new vscode.TreeItem(abtn.text, collapsibleState);
+        item.contextValue = 'azure.batch.' + abtn.kind;
+        return item;
+    }
+    async getChildren(abtn? : AzureBatchTreeNode) : Promise<AzureBatchTreeNode[]> {
+        if (abtn) {
+            if (isRootNode(abtn)) {
+                const listResult = await batch.listResources(shell.exec, abtn.resourceType);
+                if (shell.isCommandError(listResult)) {
+                    return [];
+                }
+                return listResult.map((r) => new ResourceNode(r.id));
+            } else if (isResourceNode(abtn)) {
+                return [];
+            }
+            return [];
+        }
+        return [new RootNode("Jobs", 'job'), new RootNode("Pools", 'pool')];
+    }
+}
+
+function isRootNode(node : AzureBatchTreeNode) : node is RootNode {
+    return node.kind == 'root';
+}
+
+function isResourceNode(node : AzureBatchTreeNode) : node is ResourceNode {
+    return node.kind == 'resource';
+}
+
+export interface AzureBatchTreeNode {
+    readonly kind : AbtnKind;
+    readonly text : string;
+}
+
+type AbtnKind = 'root' | 'resource';
+
+class RootNode implements AzureBatchTreeNode {
+    constructor(readonly text : string, readonly resourceType : batch.BatchResourceType) { }
+    readonly kind : AbtnKind = 'root';
+}
+
+class ResourceNode implements AzureBatchTreeNode {
+    constructor(readonly text : string) { }
+    readonly kind : AbtnKind = 'resource';
+}

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -50,8 +50,8 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
         return JSON.stringify(getResult, null, 2);
     }
     refresh(): void {
-		this._onDidChangeTreeData.fire();
-	}
+        this._onDidChangeTreeData.fire();
+    }
 }
 
 function isRootNode(node : AzureBatchTreeNode) : node is RootNode {
@@ -87,5 +87,4 @@ class ErrorNode implements AzureBatchTreeNode {
     constructor(readonly text : string) { }
     readonly kind : AbtnKind = 'error';
     readonly uri : vscode.Uri = vscode.Uri.parse(`${UriScheme}://`);
-  
 }

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -9,7 +9,7 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
 	private _onDidChangeTreeData: vscode.EventEmitter<AzureBatchTreeNode | undefined> = new vscode.EventEmitter<AzureBatchTreeNode | undefined>();
 	readonly onDidChangeTreeData: vscode.Event<AzureBatchTreeNode | undefined> = this._onDidChangeTreeData.event;
     getTreeItem(abtn : AzureBatchTreeNode) : vscode.TreeItem {
-        const collapsibleState = abtn.kind == 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
+        const collapsibleState = abtn.kind === 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
         let item = new vscode.TreeItem(abtn.text, collapsibleState);
         item.contextValue = 'azure.batch.' + abtn.kind;
         if (isResourceNode(abtn)) {
@@ -55,11 +55,11 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
 }
 
 function isRootNode(node : AzureBatchTreeNode) : node is RootNode {
-    return node.kind == 'root';
+    return node.kind === 'root';
 }
 
 function isResourceNode(node : AzureBatchTreeNode) : node is ResourceNode {
-    return node.kind == 'resource';
+    return node.kind === 'resource';
 }
 
 export interface AzureBatchTreeNode {

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -8,8 +8,11 @@ export const UriScheme : string = 'ab';
 export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTreeNode>, vscode.TextDocumentContentProvider {
 	private _onDidChangeTreeData: vscode.EventEmitter<AzureBatchTreeNode | undefined> = new vscode.EventEmitter<AzureBatchTreeNode | undefined>();
 	readonly onDidChangeTreeData: vscode.Event<AzureBatchTreeNode | undefined> = this._onDidChangeTreeData.event;
+
     getTreeItem(abtn : AzureBatchTreeNode) : vscode.TreeItem {
-        const collapsibleState = abtn.kind === 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
+        const collapsibleState = abtn.kind === 'root'
+            ? vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.None;
         let item = new vscode.TreeItem(abtn.text, collapsibleState);
         item.contextValue = 'azure.batch.' + abtn.kind;
         if (isResourceNode(abtn)) {
@@ -21,6 +24,7 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
         }
         return item;
     }
+
     async getChildren(abtn? : AzureBatchTreeNode) : Promise<AzureBatchTreeNode[]> {
         if (abtn) {
             if (isRootNode(abtn)) {
@@ -37,11 +41,13 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
         }
         return [new RootNode("Jobs", 'job'), new RootNode("Pools", 'pool')];
     }
+
     provideTextDocumentContent(uri: vscode.Uri, token : vscode.CancellationToken) : vscode.ProviderResult<string> {
         const resourceType = <batch.BatchResourceType> uri.authority;
-        const id : string = uri.path.substring(0, uri.path.length - '.json'.length).substr(1);
+        const id : string = uri.path.substring(1, uri.path.length - '.json'.length);
         return this.getBatchResourceJson(resourceType, id);
     }
+
     private async getBatchResourceJson(resourceType : batch.BatchResourceType, id : string) : Promise<string> {
         const getResult = await batch.getResource(shell.exec, resourceType, id);
         if (shell.isCommandError(getResult)) {
@@ -49,6 +55,7 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
         }
         return JSON.stringify(getResult, null, 2);
     }
+
     refresh(): void {
         this._onDidChangeTreeData.fire();
     }

--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -5,6 +5,8 @@ import * as shell from './shell';
 export const UriScheme : string = 'ab';
 
 export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTreeNode>, vscode.TextDocumentContentProvider {
+	private _onDidChangeTreeData: vscode.EventEmitter<AzureBatchTreeNode | undefined> = new vscode.EventEmitter<AzureBatchTreeNode | undefined>();
+	readonly onDidChangeTreeData: vscode.Event<AzureBatchTreeNode | undefined> = this._onDidChangeTreeData.event;
     getTreeItem(abtn : AzureBatchTreeNode) : vscode.TreeItem {
         const collapsibleState = abtn.kind == 'root' ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
         let item = new vscode.TreeItem(abtn.text, collapsibleState);
@@ -45,6 +47,9 @@ export class AzureBatchProvider implements vscode.TreeDataProvider<AzureBatchTre
         }
         return JSON.stringify(getResult, null, 2);
     }
+    refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
 }
 
 function isRootNode(node : AzureBatchTreeNode) : node is RootNode {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -114,7 +114,7 @@ export async function getResource(shellExec : (command : string) => Promise<IShe
 }
 
 export function makeTemplate(resource : any, resourceType : BatchResourceType) : any {
-    const filtered = removeProperties(resource, unsettableProperties(resourceType));
+    const filtered = withoutProperties(resource, unsettableProperties(resourceType));
     // TODO: strip defaults (particularly nulls or empty objects) - we get null-stripping as a side-effect of transformProperties but shouldn't rely on this!
     const templateBody = filtered;
 
@@ -131,7 +131,7 @@ export function makeTemplate(resource : any, resourceType : BatchResourceType) :
     return template;
 }
 
-function removeProperties(resource : any, properties : string[]) : any {
+function withoutProperties(resource : any, properties : string[]) : any {
     var result : any = {};
     for (const property in resource) {
         if (properties.indexOf(property) < 0) {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -149,11 +149,14 @@ function removeProperties(resource : any, properties : string[]) : any {
 function transformProperties(obj : any, properties: string[], transform : (original : string | undefined) => string | undefined) : any {
     var result : any = {};
     for (const property in obj) {
-        if (obj[property] instanceof Object) {
-            result[property] = transformProperties(obj[property], properties, transform);
+        const value = obj[property];
+        if (value instanceof Array) {
+            result[property] = value.map((e : any) => transformProperties(e, properties, transform));
+        } else if (value instanceof Object) {
+            result[property] = transformProperties(value, properties, transform);
         } else {
             const needsTransform = properties.indexOf(property) >= 0;
-            const resultProperty = needsTransform ? transform(obj[property]) : obj[property];
+            const resultProperty = needsTransform ? transform(value) : value;
             if (resultProperty !== undefined && resultProperty !== null) {
                 result[property] = resultProperty;
             }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -134,18 +134,6 @@ function removeProperties(resource : any, properties : string[]) : any {
     return result;
 }
 
-// function transformProperties(resource : any, properties : string[], transform : (original : string | undefined) => string | undefined) : any {
-//     var result : any = {};
-//     for (const property in resource) {
-//         const needsTransform = properties.indexOf(property) >= 0;
-//         const resultProperty = needsTransform ? transform(resource[property]) : resource[property];
-//         if (resultProperty) {
-//             result[property] = resultProperty;
-//         }
-//     }
-//     return result;    
-// }
-
 function transformProperties(obj : any, properties: string[], transform : (original : string | undefined) => string | undefined) : any {
     var result : any = {};
     for (const property in obj) {
@@ -154,7 +142,7 @@ function transformProperties(obj : any, properties: string[], transform : (origi
         } else {
             const needsTransform = properties.indexOf(property) >= 0;
             const resultProperty = needsTransform ? transform(obj[property]) : obj[property];
-            if (resultProperty) {
+            if (resultProperty !== undefined && resultProperty !== null) {
                 result[property] = resultProperty;
             }
         }
@@ -167,6 +155,8 @@ function durationProperties(resourceType : BatchResourceType) : string[] {
     switch (resourceType) {
         case 'job':
             return [ 'maxWallClockTime' ];
+        case 'pool':
+            return [ 'resizeTimeout' ];
         default:
             throw `unknown resource type ${resourceType}`;
     }
@@ -185,6 +175,8 @@ function unsettablePropertiesCore(resourceType : BatchResourceType) : string[] {
     switch (resourceType) {
         case 'job':
             return ["executionInfo", "stats"];
+        case 'pool':
+            return ["allocationState", "allocationStateTransitionTime", "resizeErrors", "currentDedicatedNodes", "currentLowPriorityNodes", "autoScaleRun", "stats"];
         default:
             throw `unknown resource type ${resourceType}`;
     }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,92 @@
+export function parseBatchTemplate(text : string, resourceType : BatchResourceType) : IBatchTemplate | null {
+    
+    try {
+
+        const jobject : any = JSON.parse(text);
+        if (!jobject) {
+            return null;
+        }
+
+        if (!jobject[resourceType]) {
+            return null;
+        }
+
+        return parseTemplateCore(jobject);
+
+    } catch (SyntaxError) {
+        return null;
+    }
+}
+
+function parseTemplateCore(json : any) : IBatchTemplate {
+    
+    const parameters : IBatchTemplateParameter[] = [];
+
+    for (const p in json.parameters || []) {
+        const pval : any = json.parameters[p];
+        parameters.push({
+            name : p,
+            dataType : <BatchTemplateParameterDataType>(pval['type']),
+            defaultValue : pval['defaultValue'],
+            allowedValues : pval['allowedValues'],
+            metadata : <IBatchTemplateParameterMetadata>(pval['metadata']),
+        })
+    }
+
+    return { parameters: parameters };
+
+}
+
+export function parseParameters(text : string) : IParameterValue[] {
+    try {
+
+        const jobject : any = JSON.parse(text);
+        if (!jobject) {
+            return [];
+        }
+
+        return parseParametersCore(jobject);
+
+    } catch (SyntaxError) {
+        return [];
+    }
+}
+
+function parseParametersCore(json : any) : IParameterValue[] {
+    
+    const parameters : IParameterValue[] = [];
+
+    for (const key in json) {
+        parameters.push({
+            name : key,
+            value : json[key]
+        })
+    }
+
+    return parameters;
+}
+
+export interface IBatchTemplate {
+    readonly parameters : IBatchTemplateParameter[];
+}
+
+export interface IBatchTemplateParameter {
+    readonly name : string;
+    readonly dataType : BatchTemplateParameterDataType;
+    readonly defaultValue? : any;
+    readonly allowedValues? : any[];
+    readonly metadata? : IBatchTemplateParameterMetadata;
+}
+
+export interface IBatchTemplateParameterMetadata {
+    readonly description : string;
+}
+
+export type BatchTemplateParameterDataType = 'int' | 'string' | 'bool';
+
+export interface IParameterValue {
+    readonly name : string;
+    readonly value : any;
+}
+
+export type BatchResourceType = 'job' | 'pool';

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -28,7 +28,7 @@ function looksLikeTemplate(json : any, resourceType : BatchResourceType) : boole
     }
 
     if (resourceDecl.type && resourceDecl.properties) {
-        return resourceDecl.type == templateResourceType(resourceType);
+        return resourceDecl.type === templateResourceType(resourceType);
     }
 
     return false;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -169,7 +169,7 @@ function transformProperties(obj : any, properties: string[], transform : (origi
 function durationProperties(resourceType : BatchResourceType) : string[] {
     switch (resourceType) {
         case 'job':
-            return [ 'maxWallClockTime' ];
+            return [ 'maxWallClockTime', 'retentionTime' ];
         case 'pool':
             return [ 'resizeTimeout' ];
         default:

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -2,20 +2,20 @@ import { IShellExecResult, ICommandError } from './shell';
 import * as duration from './duration';
 import * as host from './host';
 
-export function parseBatchTemplate(text : string, resourceType : BatchResourceType) : IBatchResource | null {
+export function parseBatchTemplate(text : string, resourceType : BatchResourceType) : IBatchResource {
     try {
         const jobject : any = JSON.parse(text);
         if (!jobject) {
-            return null;
+            return { isTemplate: false, templateValidationFailure: 'Unable to parse current document as a JSON file', parameters: [] };
         }
 
         if (looksLikeTemplate(jobject, resourceType)) {
             return parseTemplateCore(jobject);
         }
 
-        return { isTemplate: false, parameters: [] };
+        return { isTemplate: false, templateValidationFailure: `Current document is not a template - expected a ${resourceType} element with type ${templateResourceType(resourceType)}`, parameters: [] };
     } catch (SyntaxError) {
-        return null;
+        return { isTemplate: false, templateValidationFailure: 'Unable to parse current document as a JSON file', parameters: [] };
     }
 }
 
@@ -58,7 +58,7 @@ function parseTemplateCore(json : any) : IBatchResource {
         })
     }
 
-    return { isTemplate: true, parameters: parameters };
+    return { isTemplate: true, templateValidationFailure: '', parameters: parameters };
 }
 
 export function parseParameters(text : string) : IParameterValue[] {
@@ -194,6 +194,7 @@ function unsettablePropertiesCore(resourceType : BatchResourceType) : string[] {
 
 export interface IBatchResource {
     readonly isTemplate : boolean;
+    readonly templateValidationFailure : string;
     readonly parameters : IBatchTemplateParameter[];
 }
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,5 +1,6 @@
 import { IShellExecResult, ICommandError } from './shell';
 import * as duration from './duration';
+import * as host from './host';
 
 export function parseBatchTemplate(text : string, resourceType : BatchResourceType) : IBatchResource | null {
     try {
@@ -71,6 +72,7 @@ export function parseParameters(text : string) : IParameterValue[] {
         return parseParametersCore(jobject);
 
     } catch (SyntaxError) {
+        host.writeOutput("Can't use candidate parameter file at it's not valid JSON - prompting for parameters instead");
         return [];
     }
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -2,9 +2,7 @@ import { IShellExecResult, ICommandError } from './shell';
 import * as duration from './duration';
 
 export function parseBatchTemplate(text : string, resourceType : BatchResourceType) : IBatchResource | null {
-    
     try {
-
         const jobject : any = JSON.parse(text);
         if (!jobject) {
             return null;
@@ -15,7 +13,6 @@ export function parseBatchTemplate(text : string, resourceType : BatchResourceTy
         }
 
         return { isTemplate: false, parameters: [] };
-
     } catch (SyntaxError) {
         return null;
     }
@@ -47,7 +44,6 @@ function plural(resourceType : BatchResourceType) : string {
 }
 
 function parseTemplateCore(json : any) : IBatchResource {
-    
     const parameters : IBatchTemplateParameter[] = [];
 
     for (const p in json.parameters || []) {
@@ -62,7 +58,6 @@ function parseTemplateCore(json : any) : IBatchResource {
     }
 
     return { isTemplate: true, parameters: parameters };
-
 }
 
 export function parseParameters(text : string) : IParameterValue[] {
@@ -81,7 +76,6 @@ export function parseParameters(text : string) : IParameterValue[] {
 }
 
 function parseParametersCore(json : any) : IParameterValue[] {
-    
     const parameters : IParameterValue[] = [];
 
     for (const key in json) {
@@ -118,7 +112,6 @@ export async function getResource(shellExec : (command : string) => Promise<IShe
 }
 
 export function makeTemplate(resource : any, resourceType : BatchResourceType) : any {
-
     const filtered = removeProperties(resource, unsettableProperties(resourceType));
     // TODO: strip defaults (particularly nulls or empty objects) - we get null-stripping as a side-effect of transformProperties but shouldn't rely on this!
     const templateBody = filtered;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -104,6 +104,19 @@ export async function listResources(shellExec : (command : string) => Promise<IS
     return { error : result.error };
 }
 
+export async function getResource(shellExec : (command : string) => Promise<IShellExecResult>, resourceType : BatchResourceType, id : string) : Promise<IBatchResourceContent | ICommandError> {
+    const command = `az batch ${resourceType} show --${resourceType}-id ${id}`;
+    const result = await shellExec(command);
+    if (result.exitCode === 0) {
+        const raw = JSON.parse(result.output);
+        // TODO: we have an inconsistency here where getResource fixes up empty
+        // and mangled properties on the way, but listResources does not - rationalise!
+        const durationised = transformProperties(raw, durationProperties(resourceType), duration.toISO8601);
+        return durationised;
+    }
+    return { error : result.error };
+}
+
 export function makeTemplate(resource : any, resourceType : BatchResourceType) : any {
 
     const filtered = removeProperties(resource, unsettableProperties(resourceType));

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,0 +1,61 @@
+export function toISO8601(duration: string | undefined) : string | undefined {
+    if (!duration) {
+        return undefined;
+    }
+
+    // Python CLI format is [ddd days, ] hh:mm:dd.ffffff
+    const parts = splitDaysPart(duration);
+
+    const days = parts.dayCount;
+
+    const timePart = parts.timePart;
+    const timeParts = timePart.split(':').reverse();
+
+    const seconds = Number.parseFloat(timeParts[0]);
+    const minutes = timeParts.length > 1 ? Number.parseInt(timeParts[1]) : 0;
+    const hours = timeParts.length > 2 ? Number.parseInt(timeParts[2]) : 0;
+
+    // Handle the 'default surfaced as MaxValue' case
+    if (days > 10000000) {
+        return undefined;
+    }
+
+    // Handle the zero duration case
+    if (days === 0 && hours === 0 && minutes === 0 && seconds === 0) {
+        return 'PT0S';
+    }
+
+    // Generate the ISO8601 representation
+    var iso = 'P';
+    if (days > 0) {
+        iso += days + 'D';
+    }
+    iso += 'T';
+    if (hours > 0) {
+        iso += hours + 'H';
+    }
+    if (minutes > 0) {
+        iso += minutes + 'M';
+    }
+    if (seconds > 0) {
+        iso += seconds + 'S';
+    }
+
+    return iso;
+}
+
+function splitDaysPart(duration : string) : { dayCount: number, timePart: string } {
+    const daySeps = [ 'days, ', 'day, ' ];
+
+    for (const daySep of daySeps) {
+        const daySepIndex = duration.indexOf(daySep);
+        if (daySepIndex >= 0) {
+            return {
+                dayCount: Number.parseInt(duration.substr(0, daySepIndex)),
+                timePart: duration.substr(daySepIndex + daySep.length)
+            };
+        }
+    }
+
+    return { dayCount: 0, timePart: duration };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ async function createResourceImpl(doc : vscode.TextDocument, resourceType : batc
 
     const knownParametersText = getParameterJson(parameterFile);
     const knownParameters = batch.parseParameters(knownParametersText);
-    const isKnownParameter = (n : string) => knownParameters.findIndex((p) => p.name == n) >= 0;
+    const isKnownParameter = (n : string) => knownParameters.findIndex((p) => p.name === n) >= 0;
     const anyUnknownParameters = templateInfo.parameters.findIndex((p) => !isKnownParameter(p.name)) >= 0;
 
     const tempParameterInfo = anyUnknownParameters ? await createTempParameterFile(templateInfo, knownParameters) : undefined;
@@ -169,7 +169,7 @@ function getParameterJson(parameterFile : IParameterFileInfo) : string {
 async function createTempParameterFile(jobTemplateInfo : batch.IBatchResource, knownParameters : batch.IParameterValue[]) : Promise<ITempFileInfo | undefined> {
     let parameterObject : any = {};
     for (const p of jobTemplateInfo.parameters) {
-        const known = knownParameters.find((pv) => pv.name == p.name);
+        const known = knownParameters.find((pv) => pv.name === p.name);
         const value = known ? known.value : await promptForParameterValue(p);
         if (value) {
             parameterObject[p.name] = value;
@@ -389,9 +389,9 @@ function findProperty(symbols: vscode.SymbolInformation[], position: vscode.Posi
 }
 
 function getParameterTypeName(value : any) : string {
-    return (value instanceof Number || typeof value == 'number') ? 'integer' :
-        (value instanceof Boolean || typeof value == 'boolean') ? 'boolean' :
-        (value instanceof String || typeof value == 'string') ? 'string' :
+    return (value instanceof Number || typeof value === 'number') ? 'integer' :
+        (value instanceof Boolean || typeof value === 'boolean') ? 'boolean' :
+        (value instanceof String || typeof value === 'string') ? 'string' :
         'object';
 }
 
@@ -433,7 +433,7 @@ class ParameterReferenceCompletionItemProvider implements vscode.CompletionItemP
 async function provideCompletionItemsCore(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) : Promise<vscode.CompletionItem[]> {
     const sis : vscode.SymbolInformation[] = await getJsonSymbols(document);  // We use this rather than JSON.parse because the document is likely to be invalid JSON at the time the user is in the middle of typing the completion trigger
     if (sis) {
-        return sis.filter((si) => si.containerName == 'parameters')
+        return sis.filter((si) => si.containerName === 'parameters')
                   .map((si) => completionItemFor(si));
     }
     return [];
@@ -465,7 +465,7 @@ function parameterRefs(text : string) : IParameterRefMatch[] {
 }
 
 async function diagnoseTemplateProblems(document : vscode.TextDocument) : Promise<void> {
-    if (document.languageId != 'json') {
+    if (document.languageId !== 'json') {
         return;
     }
 
@@ -473,7 +473,7 @@ async function diagnoseTemplateProblems(document : vscode.TextDocument) : Promis
 
     const sis : vscode.SymbolInformation[] = await getJsonSymbols(document);
     if (sis && sis.length > 0 /* don't report warnings just because the symbols haven't loaded yet */) {
-        const paramNames = sis.filter((si) => si.containerName == 'parameters')
+        const paramNames = sis.filter((si) => si.containerName === 'parameters')
                               .map((si) => si.name);
         const paramRefs = parameterRefs(document.getText());
         if (paramRefs) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,197 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as shelljs from 'shelljs';
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+
+import * as path from './path';
+import * as batch from './batch';
+
+var output : vscode.OutputChannel = vscode.window.createOutputChannel('Azure Batch');
+
+export function activate(context: vscode.ExtensionContext) {
+
+    let disposables = [
+        vscode.commands.registerCommand('azure.batch.createJob', createJob),
+        vscode.commands.registerCommand('azure.batch.createPool', createPool)
+    ];
+
+    disposables.forEach((d) => context.subscriptions.push(d), this);
+}
+
+export function deactivate() {
+}
+
+function withActiveDocument(action: (doc : vscode.TextDocument) => void) {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+        return;
+    }
+
+    const doc = activeEditor.document;
+    if (!doc) {
+        return;
+    }
+
+    action(doc);
+}
+
+function createJob() {
+    withActiveDocument((doc) => createResourceImpl(doc, 'job'));
+}
+
+function createPool() {
+    withActiveDocument((doc) => createResourceImpl(doc, 'pool'));
+}
+
+async function createResourceImpl(doc : vscode.TextDocument, resourceType : batch.BatchResourceType) {
+
+    const templateInfo = batch.parseBatchTemplate(doc.getText(), resourceType);
+    if (!templateInfo) {
+        await vscode.window.showErrorMessage(`Current file is not an Azure Batch ${resourceType} template.`);  // TODO: support job JSON
+        return;
+    }
+
+    const templateFileName = doc.fileName;  // TODO: handle the case where the doc has never been saved
+
+    if (doc.isDirty) {
+        await doc.save();
+    }
+
+    const parameterFile = await getParameterFile(templateFileName, resourceType);
+
+    const knownParametersText = getParameterJson(parameterFile);
+    const knownParameters = batch.parseParameters(knownParametersText);
+    const isKnownParameter = (n : string) => knownParameters.findIndex((p) => p.name == n) >= 0;
+    const anyUnknownParameters = templateInfo.parameters.findIndex((p) => !isKnownParameter(p.name)) >= 0;
+
+    const tempParameterInfo = anyUnknownParameters ? await createTempParameterFile(templateInfo, knownParameters) : undefined;
+
+    if (tempParameterInfo && tempParameterInfo.abandoned) {
+        return;
+    }
+
+    const parameterFilePath = tempParameterInfo ? tempParameterInfo.path : parameterFile.path;
+
+    output.show();
+    output.appendLine(`Creating Azure Batch ${resourceType}...`);
+
+    shelljs.exec(`az batch ${resourceType} create --template "${doc.fileName}" --parameters "${parameterFilePath}"`, { async: true }, (code : number, stdout : string, stderr : string) => {
+        if (tempParameterInfo) {
+            fs.unlinkSync(tempParameterInfo.path);
+        }
+
+        if (code !== 0 || stderr) {  // TODO: figure out what to check (if anything) - problem is that the CLI can return exit code 0 on failure... but it writes to stderr on success too (the experimental feature warnings)
+            output.appendLine(stderr);
+        } else {
+            output.appendLine(stdout);
+        }
+
+        output.appendLine("Done");
+    });
+
+}
+
+async function getParameterFile(templateFileName : string, resourceType : batch.BatchResourceType) : Promise<IParameterFileInfo> {
+    const templateFileRoot = path.stripExtension(templateFileName);
+    const templateFileDir = path.directory(templateFileName);
+
+    const parameterFileNames = [
+        templateFileRoot + '.parameters.json',
+        templateFileDir + `/${resourceType}parameters.json`,
+        templateFileDir + `/parameters.${resourceType}.json`,
+        templateFileDir + '/parameters.json'
+    ];
+    const parameterFileName = parameterFileNames.find(s => fs.existsSync(s));
+
+    if (!parameterFileName) {
+        return {
+            exists: false,
+            path: ''
+        };
+    }
+
+    const parametersDoc = vscode.workspace.textDocuments.find((d) => path.equal(d.fileName, parameterFileName));
+    if (parametersDoc && parametersDoc.isDirty) {
+        await parametersDoc.save();
+    }
+
+    return {
+        exists: true,
+        path: parameterFileName,
+        document: parametersDoc
+    };
+}
+
+function getParameterJson(parameterFile : IParameterFileInfo) : string {
+    if (parameterFile.exists) {
+        return parameterFile.document ? parameterFile.document.getText() : fs.readFileSync(parameterFile.path, 'utf8');
+    }
+    return '{}';
+}
+
+async function createTempParameterFile(jobTemplateInfo : batch.IBatchTemplate, knownParameters : batch.IParameterValue[]) : Promise<ITempFileInfo | undefined> {
+    let parameterObject : any = {};
+    for (const p of jobTemplateInfo.parameters) {
+        const known = knownParameters.find((pv) => pv.name == p.name);
+        const value = known ? known.value : await promptForParameterValue(p);
+        if (value) {
+            parameterObject[p.name] = value;
+        } else {
+            return { abandoned: true, path: '' };
+        }
+    }
+
+    const json = JSON.stringify(parameterObject);
+
+    const tempFile = tmp.fileSync();
+    
+    fs.writeFileSync(tempFile.name, json, { encoding: 'utf8' });
+
+    return { abandoned: false, path: tempFile.name };
+}
+
+async function promptForParameterValue(parameter : batch.IBatchTemplateParameter) : Promise<any> {
+    let description = '';
+    if (parameter.metadata) {
+        description = ` | ${parameter.metadata.description}`;
+    }
+
+    if (parameter.allowedValues) {
+        const allowedValueQuickPicks = parameter.allowedValues.map((v) => quickPickFor(v));
+        const opts = { placeHolder: `${parameter.name}${description}` };
+        const selectedValue = await vscode.window.showQuickPick(allowedValueQuickPicks, opts);
+        return selectedValue ? selectedValue.value : undefined;
+    } else {
+        const opts = {
+            prompt: `${parameter.name}${description} (${parameter.dataType})`,
+            value: parameter.defaultValue ? String(parameter.defaultValue) : undefined
+            // TODO: set the validateInput option to do range checking
+        };
+        return await vscode.window.showInputBox(opts);
+    }
+}
+
+function quickPickFor(value : any) : AllowedValueQuickPickItem {
+    return {
+        label: String(value),
+        description: '',
+        value: value
+    };
+}
+
+interface AllowedValueQuickPickItem extends vscode.QuickPickItem {
+    value : any
+}
+
+interface ITempFileInfo {
+    readonly abandoned : boolean;
+    readonly path : string;
+}
+
+interface IParameterFileInfo {
+    readonly exists : boolean;
+    readonly path : string;
+    readonly document? : vscode.TextDocument;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,8 +77,8 @@ function createPool() {
 async function createResourceImpl(doc : vscode.TextDocument, resourceType : batch.BatchResourceType) {
 
     const templateInfo = batch.parseBatchTemplate(doc.getText(), resourceType);
-    if (!templateInfo) {
-        await vscode.window.showErrorMessage(`Current file is not an Azure Batch ${resourceType} template.`);
+    if (!templateInfo.isTemplate) {
+        await vscode.window.showErrorMessage(templateInfo.templateValidationFailure);
         return;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,7 +233,7 @@ async function createTemplateFromResource(resourceType : batch.BatchResourceType
     const resources = await batch.listResources(shell.exec, resourceType);
 
     if (shell.isCommandError(resources)) {
-        host.writeOutput(`Error getting ${resourceTypePlural} from account\n\nDetails:\n\n` + resources.error);
+        host.writeOutput(`Error getting ${resourceTypePlural} from account.\n\nDetails:\n\n` + resources.error);
         return;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,20 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('azure.batch.createTemplateFromJob', createTemplateFromJob),
         vscode.commands.registerCommand('azure.batch.createTemplateFromPool', createTemplateFromPool),
         vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter),
-        vscode.commands.registerCommand('azure.batch.get', (node: azurebatchtree.AzureBatchTreeNode) => {
-            vscode.workspace.openTextDocument(node.uri).then((doc) => vscode.window.showTextDocument(doc));
-        }),
-        vscode.commands.registerCommand('azure.batch.getAsTemplate', (node: azurebatchtree.AzureBatchTreeNode) => {
-            // TODO: horrible smearing of responsibilities and duplication of code across this
-            // and the get command - rationalise!
-            const uri = node.uri;
-            const resourceType = <batch.BatchResourceType> uri.authority;
-            const id : string = uri.path.substring(0, uri.path.length - '.json'.length).substr(1);
-            createTemplateFromSpecificResource(resourceType, id);
-        }),
+        vscode.commands.registerCommand('azure.batch.get', viewnodeGet),
+        vscode.commands.registerCommand('azure.batch.getAsTemplate', viewnodeGetAsTemplate),
         vscode.commands.registerCommand('azure.batch.refresh', () => {vscode.window.showWarningMessage('not implemented');}),
         vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider),
-        vscode.workspace.registerTextDocumentContentProvider('ab', azureBatchProvider)
+        vscode.workspace.registerTextDocumentContentProvider(azurebatchtree.UriScheme, azureBatchProvider)
     ];
 
     disposables.forEach((d) => context.subscriptions.push(d), this);
@@ -392,6 +383,20 @@ function getParameterTypeName(value : any) : string {
         (value instanceof Boolean || typeof value == 'boolean') ? 'boolean' :
         (value instanceof String || typeof value == 'string') ? 'string' :
         'object';
+}
+
+async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
+    const document = await vscode.workspace.openTextDocument(node.uri)
+    vscode.window.showTextDocument(document);
+}
+
+async function viewnodeGetAsTemplate(node : azurebatchtree.AzureBatchTreeNode) {
+    // TODO: horrible smearing of responsibilities and duplication of code across this
+    // and the get command - rationalise!
+    const uri = node.uri;
+    const resourceType = <batch.BatchResourceType> uri.authority;
+    const id : string = uri.path.substring(0, uri.path.length - '.json'.length).substr(1);
+    await createTemplateFromSpecificResource(resourceType, id);
 }
 
 interface AllowedValueQuickPickItem extends vscode.QuickPickItem {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,10 +190,7 @@ async function createTempParameterFile(jobTemplateInfo : batch.IBatchResource, k
 }
 
 async function promptForParameterValue(parameter : batch.IBatchTemplateParameter) : Promise<any> {
-    let description = '';
-    if (parameter.metadata) {
-        description = ` | ${parameter.metadata.description}`;
-    }
+    const description = (parameter.metadata && parameter.metadata.description) ? ` | ${parameter.metadata.description}` : '';
 
     if (parameter.allowedValues) {
         const allowedValueQuickPicks = parameter.allowedValues.map((v) => quickPickFor(v));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,8 +384,8 @@ function findProperty(symbols: vscode.SymbolInformation[], position: vscode.Posi
 }
 
 function getParameterTypeName(value : any) : string {
-    return (value instanceof Number || typeof value === 'number') ? 'integer' :
-        (value instanceof Boolean || typeof value === 'boolean') ? 'boolean' :
+    return (value instanceof Number || typeof value === 'number') ? 'int' :
+        (value instanceof Boolean || typeof value === 'boolean') ? 'bool' :
         (value instanceof String || typeof value === 'string') ? 'string' :
         'object';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,10 @@ async function createResourceImpl(doc : vscode.TextDocument, resourceType : batc
     const templateFileName = doc.fileName;  // TODO: handle the case where the doc has never been saved
 
     if (doc.isDirty) {
-        await doc.save();
+        const saved = await doc.save();
+        if (!saved) {
+            return;
+        }
     }
 
     // TODO: this results in the unnecessary creation and deletion of a temp file in

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('azure.batch.createJob', createJob),
         vscode.commands.registerCommand('azure.batch.createPool', createPool),
         vscode.commands.registerCommand('azure.batch.createTemplateFromJob', createTemplateFromJob),
+        vscode.commands.registerCommand('azure.batch.createTemplateFromPool', createTemplateFromPool),
         vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter)
     ];
 
@@ -193,6 +194,16 @@ function quickPickFor(value : any) : AllowedValueQuickPickItem {
 async function createTemplateFromJob() {
     const resourceType : batch.BatchResourceType = 'job';
     const resourceTypePlural = 'jobs';
+    await createTemplateFromResource(resourceType, resourceTypePlural);
+}
+
+async function createTemplateFromPool() {
+    const resourceType : batch.BatchResourceType = 'pool';
+    const resourceTypePlural = 'pools';
+    await createTemplateFromResource(resourceType, resourceTypePlural);
+}
+
+async function createTemplateFromResource(resourceType : batch.BatchResourceType, resourceTypePlural : string) {
 
     output.appendLine(`Getting list of ${resourceTypePlural} from account...`);
 
@@ -211,9 +222,6 @@ async function createTemplateFromJob() {
         const template = batch.makeTemplate(resource, resourceType);
         const filename = resource.id + `.${resourceType}template.json`;
         createFile(filename, JSON.stringify(template, null, 2));
-
-        // ask which properties they want to templatise (how? does VSC have a multi-select UI or do we use the text editor?)
-        // oh, we could have a 'convert to parameter' command
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('azure.batch.refresh', () => azureBatchProvider.refresh()),
         vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider),
         vscode.workspace.registerTextDocumentContentProvider(azurebatchtree.UriScheme, azureBatchProvider),
-        vscode.languages.registerCompletionItemProvider('json', new ParameterReferenceCompletionItemProvider(), '!')
+        vscode.languages.registerCompletionItemProvider('json', new ParameterReferenceCompletionItemProvider())
     ];
 
     disposables.forEach((d) => context.subscriptions.push(d), this);
@@ -454,7 +454,7 @@ async function provideCompletionItemsCore(document: vscode.TextDocument, positio
 }
 
 function completionItemFor(si : vscode.SymbolInformation) : vscode.CompletionItem {
-    let ci = new vscode.CompletionItem(`"batch.parameter('${si.name}')"`);
+    let ci = new vscode.CompletionItem(`batch.parameter('${si.name}')`);
     ci.insertText = `"[parameter('${si.name}')]"`;
     ci.detail = `Reference to the '${si.name}' template parameter`;
     return ci;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,6 +136,7 @@ async function getParameterFile(templateFileName : string, resourceType : batch.
     const parameterFileNames = [
         templateFileRoot + '.parameters.json',
         templateFileDir + `/${resourceType}parameters.json`,
+        templateFileDir + `/${resourceType}.parameters.json`,
         templateFileDir + `/parameters.${resourceType}.json`,
         templateFileDir + '/parameters.json'
     ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -444,7 +444,7 @@ async function provideCompletionItemsCore(document: vscode.TextDocument, positio
 
 function completionItemFor(si : vscode.SymbolInformation) : vscode.CompletionItem {
     let ci = new vscode.CompletionItem(`batch.parameter-ref('${si.name}')`);
-    ci.insertText = `"[parameter('${si.name}')]"`;
+    ci.insertText = `"[parameters('${si.name}')]"`;
     ci.documentation = `A reference to the '${si.name}' template parameter`;
     ci.detail = `vscode-azure-batch-tools`;
     return ci;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,17 +116,17 @@ async function createResourceImpl(doc : vscode.TextDocument, resourceType : batc
 
     host.writeOutput(`Creating Azure Batch ${resourceType}...`);
 
-    shelljs.exec(`az batch ${resourceType} create ${commandOptions}`, { async: true }, (code : number, stdout : string, stderr : string) => {
-        cleanup();
-
-        if (code !== 0 || stderr) {  // TODO: figure out what to check (if anything) - problem is that the CLI can return exit code 0 on failure... but it writes to stderr on success too (the experimental feature warnings)
-            host.writeOutput(stderr);
+    try {
+        const execResult = await shell.exec(`az batch ${resourceType} create ${commandOptions}`);
+        if (execResult.exitCode !== 0 || execResult.error) {  // TODO: figure out what to check (if anything) - problem is that the CLI can return exit code 0 on failure... but it writes to stderr on success too (the experimental feature warnings)
+            host.writeOutput(execResult.error);
         } else {
-            host.writeOutput(stdout);
+            host.writeOutput(execResult.output);
         }
-
         host.writeOutput("Done");
-    });
+    } finally {
+        cleanup();
+    }
 }
 
 async function getParameterFile(templateFileName : string, resourceType : batch.BatchResourceType) : Promise<IParameterFileInfo> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,17 +8,24 @@ import * as tmp from 'tmp';
 import * as path from './path';
 import * as batch from './batch';
 import * as shell from './shell';
+import * as azurebatchtree from './azurebatchtree';
 
 var output : vscode.OutputChannel = vscode.window.createOutputChannel('Azure Batch');
 
 export function activate(context: vscode.ExtensionContext) {
+
+    const azureBatchProvider = new azurebatchtree.AzureBatchProvider();
 
     let disposables = [
         vscode.commands.registerCommand('azure.batch.createJob', createJob),
         vscode.commands.registerCommand('azure.batch.createPool', createPool),
         vscode.commands.registerCommand('azure.batch.createTemplateFromJob', createTemplateFromJob),
         vscode.commands.registerCommand('azure.batch.createTemplateFromPool', createTemplateFromPool),
-        vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter)
+        vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter),
+        vscode.commands.registerCommand('azure.batch.get', (node) => {}),
+        vscode.commands.registerCommand('azure.batch.getAsTemplate', (node) => {}),
+        vscode.commands.registerCommand('azure.batch.refresh', () => {}),
+        vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider)
     ];
 
     disposables.forEach((d) => context.subscriptions.push(d), this);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,14 @@ function createPool() {
 
 async function createResourceImpl(doc : vscode.TextDocument, resourceType : batch.BatchResourceType) {
 
+    // https://github.com/Microsoft/vscode/issues/29156
+    // We don't yet have a workaround for this, so for now, resort to asking the user to
+    // save the document and then re-run the command.  No, it's not great.  Sorry.
+    if (doc.isUntitled) {
+        await vscode.window.showWarningMessage("Please save the document before running this command.");
+        return;
+    }
+
     const templateInfo = batch.parseBatchTemplate(doc.getText(), resourceType);
     if (!templateInfo.isTemplate) {
         await vscode.window.showErrorMessage(templateInfo.templateValidationFailure);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,6 @@ import * as textmodels from './textmodels';
 let diagnostics : vscode.DiagnosticCollection;
 
 export function activate(context: vscode.ExtensionContext) {
-
     const azureBatchProvider = new azurebatchtree.AzureBatchProvider();
     diagnostics = vscode.languages.createDiagnosticCollection('json');
 
@@ -125,7 +124,6 @@ async function createResourceImpl(doc : vscode.TextDocument, resourceType : batc
 
         host.writeOutput("Done");
     });
-
 }
 
 async function getParameterFile(templateFileName : string, resourceType : batch.BatchResourceType) : Promise<IParameterFileInfo> {
@@ -229,7 +227,6 @@ async function createTemplateFromPool() {
 }
 
 async function createTemplateFromResource(resourceType : batch.BatchResourceType, resourceTypePlural : string) {
-
     host.writeOutput(`Getting list of ${resourceTypePlural} from account...`);
 
     const resources = await batch.listResources(shell.exec, resourceType);
@@ -257,7 +254,6 @@ async function createTemplateFile(resourceType : batch.BatchResourceType, resour
     const template = batch.makeTemplate(resource, resourceType);
     const filename = id + `.${resourceType}template.json`;
     createFile(filename, JSON.stringify(template, null, 2));
-   
 }
 
 async function createFile(filename : string, content : string) : Promise<void> {
@@ -285,7 +281,6 @@ function quickPickForResource(resource: batch.IBatchResourceContent) : AllowedVa
 }
 
 async function convertToParameter() {
-
     const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
         return;
@@ -317,7 +312,6 @@ function isTextEdit(obj : vscode.TextEdit | string) : obj is vscode.TextEdit {
 
 // TODO: any better way to make available for testing?
 export async function convertToParameterCore(document: vscode.TextDocument, selection: vscode.Selection) : Promise<vscode.TextEdit | string> {
-
     const jsonSymbols = await getJsonSymbols(document);
     if (jsonSymbols.length === 0) {
         return 'Active document is not a JSON document';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ async function createResourceImpl(doc : vscode.TextDocument, resourceType : batc
 
     const templateInfo = batch.parseBatchTemplate(doc.getText(), resourceType);
     if (!templateInfo) {
-        await vscode.window.showErrorMessage(`Current file is not an Azure Batch ${resourceType} template.`);  // TODO: support job JSON
+        await vscode.window.showErrorMessage(`Current file is not an Azure Batch ${resourceType} template.`);
         return;
     }
 
@@ -286,7 +286,7 @@ async function convertToParameter() {
 
     if (isTextEdit(convertResult)) {
         activeEditor.revealRange(convertResult.range);
-        activeEditor.selection = new vscode.Selection(convertResult.range.start, convertResult.range.end);  // TODO: this ends on the comma beforehand...}
+        activeEditor.selection = new vscode.Selection(convertResult.range.start, convertResult.range.end);
     } else {
         vscode.window.showErrorMessage(convertResult);
     }
@@ -296,7 +296,7 @@ function isTextEdit(obj : vscode.TextEdit | string) : obj is vscode.TextEdit {
     return (<vscode.TextEdit>obj).range !== undefined;
 }
 
-// TODO: need to export for testing - bah
+// TODO: any better way to make available for testing?
 export async function convertToParameterCore(document: vscode.TextDocument, selection: vscode.Selection) : Promise<vscode.TextEdit | string> {
 
     const jsonSymbols = await getJsonSymbols(document);
@@ -310,7 +310,7 @@ export async function convertToParameterCore(document: vscode.TextDocument, sele
     }
 
     const propertyContainerName = property.containerName;
-    if (!(propertyContainerName.startsWith('job.properties') || propertyContainerName.startsWith('pool.properties'))) {  // <- TODO
+    if (!(propertyContainerName.startsWith('job.properties') || propertyContainerName.startsWith('pool.properties'))) {
         return 'Selection is not a resource property';
     }
 
@@ -342,7 +342,7 @@ export async function convertToParameterCore(document: vscode.TextDocument, sele
 
     // TODO: de-horribilate horrible formatting code
     if (parametersElement) {
-        const lastExistingParameter = jsonSymbols.reverse().find((s) => s.containerName == 'parameters');  // TODO: order guarantees?
+        const lastExistingParameter = jsonSymbols.reverse().find((s) => s.containerName == 'parameters');  // not sure what order guarantees the symbol provider makes, but it's not critical if this isn't actually the last one
         const indentPerLevel = lastExistingParameter ? lastExistingParameter.location.range.start.character - parametersElement.location.range.start.character : parametersElement.location.range.start.character;
         const rawNewParameterDefnText = `"${property.name}": ${JSON.stringify(newParameterDefn, null, indentPerLevel)}`;
         const initialIndent = indentPerLevel * 2;
@@ -397,7 +397,6 @@ function findProperty(symbols: vscode.SymbolInformation[], position: vscode.Posi
     if (!containingSymbols || containingSymbols.length === 0) {
         return null;
     }
-    // TODO: is it always the last one in the collection?  Not sure what guarantees we have...
     const sorted = containingSymbols.sort((a, b) => (a.containerName || '').length - (b.containerName || '').length);
     return sorted[sorted.length - 1];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,10 +22,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('azure.batch.createTemplateFromJob', createTemplateFromJob),
         vscode.commands.registerCommand('azure.batch.createTemplateFromPool', createTemplateFromPool),
         vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter),
-        vscode.commands.registerCommand('azure.batch.get', (node) => {}),
+        vscode.commands.registerCommand('azure.batch.get', (node: azurebatchtree.AzureBatchTreeNode) => {
+            vscode.workspace.openTextDocument(node.uri).then((doc) => vscode.window.showTextDocument(doc));
+        }),
         vscode.commands.registerCommand('azure.batch.getAsTemplate', (node) => {}),
         vscode.commands.registerCommand('azure.batch.refresh', () => {}),
-        vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider)
+        vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider),
+        vscode.workspace.registerTextDocumentContentProvider('ab', azureBatchProvider)
     ];
 
     disposables.forEach((d) => context.subscriptions.push(d), this);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -454,8 +454,9 @@ async function provideCompletionItemsCore(document: vscode.TextDocument, positio
 }
 
 function completionItemFor(si : vscode.SymbolInformation) : vscode.CompletionItem {
-    let ci = new vscode.CompletionItem(`batch.parameter('${si.name}')`);
+    let ci = new vscode.CompletionItem(`batch.parameter-ref('${si.name}')`);
     ci.insertText = `"[parameter('${si.name}')]"`;
-    ci.detail = `Reference to the '${si.name}' template parameter`;
+    ci.documentation = `A reference to the '${si.name}' template parameter`;
+    ci.detail = `vscode-azure-batch-tools`;
     return ci;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,17 +236,20 @@ async function createTemplateFromResource(resourceType : batch.BatchResourceType
 
     if (pick) {
         const resource = pick.value;
-        const template = batch.makeTemplate(resource, resourceType);
-        const filename = resource.id + `.${resourceType}template.json`;
-        createFile(filename, JSON.stringify(template, null, 2));
+        await createTemplateFile(resourceType, resource, resource.id);
     }
 }
 
 async function createTemplateFromSpecificResource(resourceType: batch.BatchResourceType, id : string) {
     const resource = await batch.getResource(shell.exec, resourceType, id);
-    const template = batch.makeTemplate(resource, resourceType);  // TODO: this puts it through the durationiser twice which results in manglage
+    await createTemplateFile(resourceType, resource, id);
+}
+
+async function createTemplateFile(resourceType : batch.BatchResourceType, resource : any, id : string) {
+    const template = batch.makeTemplate(resource, resourceType);
     const filename = id + `.${resourceType}template.json`;
     createFile(filename, JSON.stringify(template, null, 2));
+   
 }
 
 async function createFile(filename : string, content : string) : Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('azure.batch.convertToParameter', convertToParameter),
         vscode.commands.registerCommand('azure.batch.get', viewnodeGet),
         vscode.commands.registerCommand('azure.batch.getAsTemplate', viewnodeGetAsTemplate),
-        vscode.commands.registerCommand('azure.batch.refresh', () => {vscode.window.showWarningMessage('not implemented');}),
+        vscode.commands.registerCommand('azure.batch.refresh', () => azureBatchProvider.refresh()),
         vscode.window.registerTreeDataProvider('azure.batch.explorer', azureBatchProvider),
         vscode.workspace.registerTextDocumentContentProvider(azurebatchtree.UriScheme, azureBatchProvider)
     ];

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+const output : vscode.OutputChannel = vscode.window.createOutputChannel('Azure Batch');
+let outputShown = false;
+
+export function writeOutput(text : string) {
+    if (!outputShown) {
+        output.show();
+    }
+    output.appendLine(text);
+}

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,3 +1,8 @@
+import * as path from 'path';
+
+export function join(...paths : string[]) : string {
+    return path.join(...paths);
+}
 export function stripExtension(filePath : string) : string {
     // TODO: this will get it wrong if the file has no extension *and* the
     // directory path contains a directory with an extension. This isn't really
@@ -10,15 +15,7 @@ export function stripExtension(filePath : string) : string {
 }
 
 export function directory(filePath : string) : string {
-    const sepIndexFwd = filePath.lastIndexOf('/');
-    const sepIndexBwd = filePath.lastIndexOf('\\');
-    const sepIndex = (sepIndexFwd > sepIndexBwd) ? sepIndexFwd : sepIndexBwd;
-    
-    if (sepIndex < 0) {
-        return process.cwd();
-    }
-
-    return filePath.substr(0, sepIndex);
+    return path.dirname(filePath);
 }
 
 export function equal(filePath1 : string, filePath2 : string) : boolean {

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,31 @@
+export function stripExtension(filePath : string) : string {
+    // TODO: this will get it wrong if the file has no extension *and* the
+    // directory path contains a directory with an extension. This isn't really
+    // a concern for our use case though would be nice to fix.
+    const sepIndex = filePath.lastIndexOf('.');
+    if (sepIndex < 0) {
+        return filePath;
+    }
+    return filePath.substr(0, sepIndex);
+}
+
+export function directory(filePath : string) : string {
+    const sepIndexFwd = filePath.lastIndexOf('/');
+    const sepIndexBwd = filePath.lastIndexOf('\\');
+    const sepIndex = (sepIndexFwd > sepIndexBwd) ? sepIndexFwd : sepIndexBwd;
+    
+    if (sepIndex < 0) {
+        return process.cwd();
+    }
+
+    return filePath.substr(0, sepIndex);
+}
+
+export function equal(filePath1 : string, filePath2 : string) : boolean {
+    const fwd1 = filePath1.replace(/\\/g, '/');
+    const fwd2 = filePath2.replace(/\\/g, '/');
+    if (process.platform === 'win32') {
+        return fwd1.toLowerCase() == fwd2.toLowerCase();
+    }
+    return fwd1 == fwd2;
+}

--- a/src/path.ts
+++ b/src/path.ts
@@ -22,7 +22,7 @@ export function equal(filePath1 : string, filePath2 : string) : boolean {
     const fwd1 = filePath1.replace(/\\/g, '/');
     const fwd2 = filePath2.replace(/\\/g, '/');
     if (process.platform === 'win32') {
-        return fwd1.toLowerCase() == fwd2.toLowerCase();
+        return fwd1.toLowerCase() === fwd2.toLowerCase();
     }
-    return fwd1 == fwd2;
+    return fwd1 === fwd2;
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,0 +1,23 @@
+import * as shelljs from 'shelljs';
+
+export function exec(command : string) : Promise<IShellExecResult> {
+    return new Promise<IShellExecResult>((resolve, reject) => {
+        shelljs.exec(command, { async: true }, (code, stdout, stderr) => {
+            resolve({ exitCode: code, output: stdout, error: stderr });
+        });
+    });
+}
+
+export interface IShellExecResult {
+    readonly exitCode : number;
+    readonly output : string;
+    readonly error : string;
+}
+
+export interface ICommandError {
+    readonly error : string;
+}
+
+export function isCommandError<T>(obj: T | ICommandError) : obj is ICommandError {
+    return (<ICommandError>obj).error !== undefined;
+}

--- a/src/textmodels.ts
+++ b/src/textmodels.ts
@@ -26,7 +26,7 @@ function indentLines(text : string, amount : number) : string {
 }
 
 function isSingleLine(range: vscode.Range) {
-    return range.start.line == range.end.line;
+    return range.start.line === range.end.line;
 }
 
 function lineStart(pos: vscode.Position) {
@@ -38,8 +38,8 @@ function immediatelyBefore(pos: vscode.Position) {
 }
 
 function templateParameterInsertionEditProvider(jsonSymbols : vscode.SymbolInformation[], propertyName : string, newParameterDefn : any) : IEditProvider {
-    const parametersElement = jsonSymbols.find((s) => s.name == 'parameters' && !s.containerName);
-    const parameterSymbols = jsonSymbols.filter((s) => s.containerName == 'parameters');
+    const parametersElement = jsonSymbols.find((s) => s.name === 'parameters' && !s.containerName);
+    const parameterSymbols = jsonSymbols.filter((s) => s.containerName === 'parameters');
     const lastExistingParameter = parameterSymbols.length > 0 ? parameterSymbols.reverse()[0] : undefined;  // not sure what order guarantees the symbol provider makes, but it's not critical if this isn't actually the last one
 
     class InsertAfterExistingParameter implements IEditProvider {

--- a/src/textmodels.ts
+++ b/src/textmodels.ts
@@ -1,0 +1,121 @@
+import * as vscode from 'vscode';
+
+export function getTemplateParameterInsertion(jsonSymbols : vscode.SymbolInformation[], propertyName : string, newParameterDefn : any) : vscode.TextEdit {
+    const editProvider = templateParameterInsertionEditProvider(jsonSymbols, propertyName, newParameterDefn);
+    return editProvider.getEdit();
+}
+
+interface IEditProvider {
+    getEdit() : vscode.TextEdit;
+}
+
+function indentOf(symbol : vscode.SymbolInformation) {
+    return symbol.location.range.start.character;
+}
+
+function indentFrom(symbol1 : vscode.SymbolInformation, symbol2 : vscode.SymbolInformation) {
+    const offset = indentOf(symbol1) - indentOf(symbol2);
+    return Math.abs(offset);
+}
+
+function indentLines(text : string, amount : number) : string {
+    const indent = ' '.repeat(amount);
+    const lines = text.split('\n');
+    const indented = lines.map((l) => indent + l);
+    return indented.join('\n');
+}
+
+function isSingleLine(range: vscode.Range) {
+    return range.start.line == range.end.line;
+}
+
+function lineStart(pos: vscode.Position) {
+    return new vscode.Position(pos.line, 0);
+}
+
+function immediatelyBefore(pos: vscode.Position) {
+    return pos.translate(0, -1);
+}
+
+function templateParameterInsertionEditProvider(jsonSymbols : vscode.SymbolInformation[], propertyName : string, newParameterDefn : any) : IEditProvider {
+    const parametersElement = jsonSymbols.find((s) => s.name == 'parameters' && !s.containerName);
+    const parameterSymbols = jsonSymbols.filter((s) => s.containerName == 'parameters');
+    const lastExistingParameter = parameterSymbols.length > 0 ? parameterSymbols.reverse()[0] : undefined;  // not sure what order guarantees the symbol provider makes, but it's not critical if this isn't actually the last one
+
+    class InsertAfterExistingParameter implements IEditProvider {
+        constructor(private readonly parametersElement : vscode.SymbolInformation, private readonly existingParameter : vscode.SymbolInformation) {
+        }
+        getEdit() : vscode.TextEdit {
+            const indentPerLevel = indentFrom(this.existingParameter, this.parametersElement);
+            const initialIndent = indentPerLevel * 2;
+            const rawNewParameterDefnText = `"${propertyName}": ${JSON.stringify(newParameterDefn, null, indentPerLevel)}`;
+            const newParameterDefnText = indentLines(rawNewParameterDefnText, initialIndent);
+            const insertText = ',\n' + newParameterDefnText;
+
+            const insertPos = this.existingParameter.location.range.end;
+            const edit = vscode.TextEdit.insert(insertPos, insertText);
+
+            return edit;
+        }
+    }
+
+    class InsertIntoEmptyParametersSection implements IEditProvider {
+        constructor(private readonly parametersElement : vscode.SymbolInformation) {
+        }
+        getEdit() : vscode.TextEdit {
+            const indentPerLevel = this.parametersElement.location.range.start.character;
+            const initialIndent = indentPerLevel * 2;
+
+            const rawNewParameterDefnText = `"${propertyName}": ${JSON.stringify(newParameterDefn, null, indentPerLevel)}`;
+            const newParameterDefnText = indentLines(rawNewParameterDefnText, initialIndent);
+            const parametersElementOnOneLine = isSingleLine(this.parametersElement.location.range);  // for the "parameters": {} case
+
+            // prefix and suffix are for fixing up cases where the parameters element is squashed on one line
+            const prefix = (parametersElementOnOneLine ? '\n' : '');
+            const suffix = (parametersElementOnOneLine ? (' '.repeat(indentPerLevel)) : '');
+            const insertText = prefix + newParameterDefnText + '\n' + suffix;  // TODO: line ending
+
+            // if the parameters element is squashed then our insert position is to the left of the closing brace (which will push things into the right place)
+            // otherwise we want to insert at the start of the line containing the closing brace
+            const closingBracePos = this.parametersElement.location.range.end;
+            const insertPos = (parametersElementOnOneLine ? immediatelyBefore(closingBracePos) : lineStart(closingBracePos));
+            const edit = vscode.TextEdit.insert(insertPos, insertText);
+
+            return edit;
+        }
+    }
+
+    class InsertNewParametersSection implements IEditProvider {
+        getEdit() : vscode.TextEdit {
+            let parameters : any = {};
+            parameters[propertyName] = newParameterDefn;
+
+            const topLevelElement = jsonSymbols.find((s) => !s.containerName);
+            const indentPerLevel = topLevelElement ? indentOf(topLevelElement) : 2;
+            const rawParametersSection = `"parameters": ${JSON.stringify(parameters, null, indentPerLevel)}`;
+
+            const parametersSectionText = indentLines(rawParametersSection, indentPerLevel);  // going in at top level so indent only once
+            const topLevelElementSeparator = topLevelElement ? ',\n' : '\n';
+            const insertText = parametersSectionText + topLevelElementSeparator;
+            
+            const insertPos = new vscode.Position(1, 0);
+            const edit = vscode.TextEdit.insert(insertPos, insertText);
+            
+            return edit;
+        }
+
+    }
+
+    if (parametersElement) {
+        if (lastExistingParameter) {
+            // We are appending after an existing parameter
+            return new InsertAfterExistingParameter(parametersElement, lastExistingParameter);
+        } else {
+            // We are inserting into an empty parameters section
+            return new InsertIntoEmptyParametersSection(parametersElement);
+        }
+    } else {
+        // There is no parameters section - we need to create one and insert it at the top of the document
+        return new InsertNewParametersSection();
+    }
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -218,7 +218,7 @@ suite('Batch Utilities Tests', () => {
     test('Parsing job template JSON captures default values', () => {
         const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJson, 'job');
         
-        const parameter = template.parameters.find((p) => p.name == 'testDefaulted');
+        const parameter = template.parameters.find((p) => p.name === 'testDefaulted');
 
         assert.notEqual(undefined, parameter);
         if (parameter) {
@@ -229,7 +229,7 @@ suite('Batch Utilities Tests', () => {
     test('Parsing job template JSON captures allowed values', () => {
         const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJson, 'job');
         
-        const parameter = template.parameters.find((p) => p.name == 'testAllowed');
+        const parameter = template.parameters.find((p) => p.name === 'testAllowed');
 
         assert.notEqual(undefined, parameter);
         if (parameter) {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -10,6 +10,7 @@ import * as assert from 'assert';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as batch from '../src/batch';
+import * as duration from '../src/duration';
 
 const nonJson = " \
   id : 'wonderjob' \
@@ -176,4 +177,29 @@ suite('Batch Utilities Tests', () => {
         
         assert.equal('vmSize', template.parameters[0].name);
     });
+});
+
+suite('Duration Parsing Tests', () => {
+
+    test('Parsing a plain time succeeds', () => {
+        assert.equal('PT5H', duration.toISO8601('5:00:00'));
+        assert.equal('PT10M', duration.toISO8601('0:10:00'));
+        assert.equal('PT30S', duration.toISO8601('0:00:30'));
+        assert.equal('PT45H10M30S', duration.toISO8601('45:10:30'));
+        assert.equal('PT45H10M30.5S', duration.toISO8601('45:10:30.50'));
+    });
+
+    test('Parsing a time containing days succeeds', () => {
+        assert.equal('P1DT5H', duration.toISO8601('1 day, 5:00:00'));
+        assert.equal('P15DT45H10M30.5S', duration.toISO8601('15 days, 45:10:30.50'));
+    });
+
+    test('Parsing a zero time succeeds', () => {
+        assert.equal('PT0S', duration.toISO8601('0:00:00'));
+    });
+
+    test('Parsing a MaxValue time returns nothing', () => {
+        assert.equal(undefined, duration.toISO8601('10675199 days, 2:48:05.477581'));
+    });
+
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -11,6 +11,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as batch from '../src/batch';
 import * as duration from '../src/duration';
+import * as extension from '../src/extension';
 
 const nonJson = " \
   id : 'wonderjob' \
@@ -102,6 +103,38 @@ const poolTemplateJson = ' \
   } \
 } \
 ';
+
+function isTextEdit(obj : vscode.TextEdit | string) : obj is vscode.TextEdit {
+    return (<vscode.TextEdit>obj).range !== undefined;
+}
+
+suite('Extension Tests', () => {
+
+    test('When there is no parameters section, a new parameter is formatted correctly', async () => {
+        const document = await vscode.workspace.openTextDocument({
+            language: 'json',
+            content: jobTemplateJsonNoParams
+        });
+
+        console.log(document.getText());
+
+        const pos = new vscode.Position(6, 18);
+        const selection = new vscode.Selection(pos, pos);
+        const result = await extension.convertToParameterCore(document, selection);
+
+        if (isTextEdit(result)) {
+
+          const text = document.getText();
+          console.log(text);
+
+          assert.equal(text, "tbd");
+
+        } else {
+          assert.fail(result, undefined, result, 'tbd');
+        }
+    });
+
+});
 
 suite('Batch Utilities Tests', () => {
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,172 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+import * as batch from '../src/batch';
+
+const nonJson = " \
+  id : 'wonderjob' \
+  poolInfo \
+      poolId : 'wonderpool' \
+";
+
+const jobJson = ' \
+{ \
+  "id" : "wonderjob", \
+  "poolInfo" : { \
+      "poolId" : "wonderpool" \
+  } \
+} \
+';
+
+const jobTemplateJson = ' \
+{ \
+  "parameters": { \
+    "jobId": { \
+      "type": "string", \
+      "metadata": { \
+        "description": "The id of the Batch job" \
+      } \
+    }, \
+    "poolId": { \
+      "type": "string", \
+      "metadata": { \
+        "description": "The id of the Batch pool on which to run the job" \
+      } \
+    }, \
+    "testDefaulted": { \
+      "type": "string", \
+      "defaultValue" : "mydef" \
+    }, \
+    "testAllowed": { \
+      "type": "string", \
+      "allowedValues" : [ "alpha", "bravo", "charlie" ] \
+    } \
+  }, \
+  "job": { \
+    "type": "Microsoft.Batch/batchAccounts/jobs", \
+    "apiVersion": "2016-12-01", \
+    "properties": { \
+      "id": "[parameters(\'jobId\')]", \
+      "poolInfo" : { \
+          "poolId" : "wonderpool" \
+      } \
+    } \
+  } \
+} \
+';
+
+const jobTemplateJsonNoParams = ' \
+{ \
+  "job": { \
+    "type": "Microsoft.Batch/batchAccounts/jobs", \
+    "apiVersion": "2016-12-01", \
+    "properties": { \
+      "id" : "wonderjob", \
+      "poolInfo" : { \
+          "poolId" : "wonderpool" \
+      } \
+    } \
+  } \
+} \
+';
+
+const poolTemplateJson = ' \
+{ \
+  "parameters": { \
+    "vmSize": { \
+      "type": "string", \
+      "allowedValues" : [ "STANDARD_A3", "STANDARD_A4" ], \
+      "metadata": { \
+        "description": "The size of virtual machine to use" \
+      } \
+    } \
+  }, \
+  "pool": { \
+    "type": "Microsoft.Batch/batchAccounts/pools", \
+    "apiVersion": "2016-12-01", \
+    "properties": { \
+      "id": "superduperpool", \
+      "vmSize": "[parameters(\'vmSize\')]", \
+      "targetDedicated": 4, \
+      "cloudServiceConfiguration": { "osFamily": 4 } \
+    } \
+  } \
+} \
+';
+
+suite('Batch Utilities Tests', () => {
+
+    test('Parsing a non-JSON document as a job template fails', () => {
+        const result = batch.parseBatchTemplate(nonJson, 'job');
+        assert.equal(result, null);
+    });
+
+    test('Parsing a job JSON as a job template fails', () => {
+        const result = batch.parseBatchTemplate(jobJson, 'job');
+        assert.equal(result, null);
+    });
+
+    test('Parsing job template JSON as a job template succeeds', () => {
+        const template = batch.parseBatchTemplate(jobTemplateJson, 'job');
+        assert.notEqual(template, null);
+    });
+
+    test('Parsing job template JSON surfaces the parameters', () => {
+        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        assert.equal(template.parameters.length, 4);
+        
+        const jobIdParameter = template.parameters[0];
+        assert.equal('jobId', jobIdParameter.name);
+        assert.equal('string', jobIdParameter.dataType);
+        assert.notEqual(undefined, jobIdParameter.metadata);
+        if (jobIdParameter.metadata) {
+            assert.equal('The id of the Batch job', jobIdParameter.metadata.description);
+        }
+    });
+
+    test('A job template can be parsed even if it has no parameters', () => {
+        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJsonNoParams, 'job');
+        assert.equal(template.parameters.length, 0);
+    });
+
+    test('Parsing job template JSON captures default values', () => {
+        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        
+        const parameter = template.parameters.find((p) => p.name == 'testDefaulted');
+
+        assert.notEqual(undefined, parameter);
+        if (parameter) {
+            assert.equal('mydef', parameter.defaultValue);
+        }
+    });
+
+    test('Parsing job template JSON captures allowed values', () => {
+        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        
+        const parameter = template.parameters.find((p) => p.name == 'testAllowed');
+
+        assert.notEqual(undefined, parameter);
+        if (parameter) {
+            assert.notEqual(undefined, parameter.allowedValues);
+            if (parameter.allowedValues) {
+                assert.equal(3, parameter.allowedValues.length);
+                assert.equal('alpha', parameter.allowedValues[0]);
+            }
+        }
+    });
+
+    test('Parsing pool template JSON surfaces the parameters', () => {
+        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(poolTemplateJson, 'pool');
+        assert.equal(template.parameters.length, 1);
+        
+        assert.equal('vmSize', template.parameters[0].name);
+    });
+});

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -109,18 +109,25 @@ suite('Batch Utilities Tests', () => {
         assert.equal(result, null);
     });
 
-    test('Parsing a job JSON as a job template fails', () => {
+    test('Parsing job JSON returns a non-template resource', () => {
         const result = batch.parseBatchTemplate(jobJson, 'job');
-        assert.equal(result, null);
+        assert.notEqual(result, null);
+        if (result !== null) {
+          assert.equal(result.isTemplate, false);
+          assert.equal(result.parameters.length, 0);
+        }
     });
 
-    test('Parsing job template JSON as a job template succeeds', () => {
+    test('Parsing job template JSON returns a job resource template', () => {
         const template = batch.parseBatchTemplate(jobTemplateJson, 'job');
         assert.notEqual(template, null);
+        if (template !== null) {
+          assert.equal(template.isTemplate, true);
+        }
     });
 
     test('Parsing job template JSON surfaces the parameters', () => {
-        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJson, 'job');
         assert.equal(template.parameters.length, 4);
         
         const jobIdParameter = template.parameters[0];
@@ -133,12 +140,12 @@ suite('Batch Utilities Tests', () => {
     });
 
     test('A job template can be parsed even if it has no parameters', () => {
-        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJsonNoParams, 'job');
+        const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJsonNoParams, 'job');
         assert.equal(template.parameters.length, 0);
     });
 
     test('Parsing job template JSON captures default values', () => {
-        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJson, 'job');
         
         const parameter = template.parameters.find((p) => p.name == 'testDefaulted');
 
@@ -149,7 +156,7 @@ suite('Batch Utilities Tests', () => {
     });
 
     test('Parsing job template JSON captures allowed values', () => {
-        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(jobTemplateJson, 'job');
+        const template = <batch.IBatchResource>batch.parseBatchTemplate(jobTemplateJson, 'job');
         
         const parameter = template.parameters.find((p) => p.name == 'testAllowed');
 
@@ -164,7 +171,7 @@ suite('Batch Utilities Tests', () => {
     });
 
     test('Parsing pool template JSON surfaces the parameters', () => {
-        const template = <batch.IBatchTemplate>batch.parseBatchTemplate(poolTemplateJson, 'pool');
+        const template = <batch.IBatchResource>batch.parseBatchTemplate(poolTemplateJson, 'pool');
         assert.equal(template.parameters.length, 1);
         
         assert.equal('vmSize', template.parameters[0].name);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/test/jobtemplate_emptyparams.after_poolid.json
+++ b/test/jobtemplate_emptyparams.after_poolid.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "poolId": {
+      "type": "string",
+      "defaultValue": "wonderpool",
+      "metadata": {
+        "description": "Value for job.properties.poolInfo.poolId"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "[parameters('poolId')]"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_emptyparams.json
+++ b/test/jobtemplate_emptyparams.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "wonderpool"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_emptyparamsoneline.after_poolid.json
+++ b/test/jobtemplate_emptyparamsoneline.after_poolid.json
@@ -1,0 +1,21 @@
+{
+  "parameters": { 
+    "poolId": {
+      "type": "string",
+      "defaultValue": "wonderpool",
+      "metadata": {
+        "description": "Value for job.properties.poolInfo.poolId"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "[parameters('poolId')]"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_emptyparamsoneline.json
+++ b/test/jobtemplate_emptyparamsoneline.json
@@ -1,0 +1,13 @@
+{
+  "parameters": { },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "wonderpool"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_multipleparams.after_poolid.json
+++ b/test/jobtemplate_multipleparams.after_poolid.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "abc" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A sequence near the end of the alphabet"
+      }
+    },
+    "xyz" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A sequence near the end of the alphabet"
+      }
+    },
+    "poolId": {
+      "type": "string",
+      "defaultValue": "wonderpool",
+      "metadata": {
+        "description": "Value for job.properties.poolInfo.poolId"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "[parameters('abc')]",
+      "poolInfo" : {
+          "poolId" : "[parameters('poolId')]"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_multipleparams.json
+++ b/test/jobtemplate_multipleparams.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "abc" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A sequence near the end of the alphabet"
+      }
+    },
+    "xyz" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A sequence near the end of the alphabet"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "[parameters('abc')]",
+      "poolInfo" : {
+          "poolId" : "wonderpool"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_noparams.after_poolid.json
+++ b/test/jobtemplate_noparams.after_poolid.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "poolId": {
+      "type": "string",
+      "defaultValue": "wonderpool",
+      "metadata": {
+        "description": "Value for job.properties.poolInfo.poolId"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "[parameters('poolId')]"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_noparams.json
+++ b/test/jobtemplate_noparams.json
@@ -1,0 +1,12 @@
+{
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "wonderjob",
+      "poolInfo" : {
+          "poolId" : "wonderpool"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_oneparam.after_poolid.json
+++ b/test/jobtemplate_oneparam.after_poolid.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "jobid" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A unique identifier for the job"
+      }
+    },
+    "poolId": {
+      "type": "string",
+      "defaultValue": "wonderpool",
+      "metadata": {
+        "description": "Value for job.properties.poolInfo.poolId"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "[parameters('jobid')]",
+      "poolInfo" : {
+          "poolId" : "[parameters('poolId')]"
+      }
+    }
+  }
+}

--- a/test/jobtemplate_oneparam.json
+++ b/test/jobtemplate_oneparam.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "jobid" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "A unique identifier for the job"
+      }
+    }
+  },
+  "job": {
+    "type": "Microsoft.Batch/batchAccounts/jobs",
+    "apiVersion": "2016-12-01",
+    "properties": {
+      "id" : "[parameters('jobid')]",
+      "poolInfo" : {
+          "poolId" : "wonderpool"
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": ".",
+        "strictNullChecks": true,
+        "alwaysStrict": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": false,
+        "strict": true
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,11 @@
+{
+	"rules": {
+		"no-unused-expression": true,
+		"no-duplicate-variable": true,
+		"no-unused-variable": true,
+		"curly": true,
+		"class-name": true,
+		"semicolon": ["always"],
+		"triple-equals": true
+	}
+}


### PR DESCRIPTION
Initial feature set for an Azure Batch VS Code extension, comprising:

* Commands for working with Azure Batch job templates and pool templates (see below)
* Snippets and auto-completion for common template elements and parameters
  * Type `batch` in a JSON file to see available snippets
* Template diagnostics
  * Warning squiggles when a template references an undeclared parameter (current status: wonky)
* Custom explorer pane displaying Azure Batch jobs and pools