### PR TITLE
Linting improvements

### DIFF
--- a/src/azurebatchtree.ts
+++ b/src/azurebatchtree.ts
@@ -87,7 +87,7 @@ class RootNode implements AzureBatchTreeNode {
 class ResourceNode implements AzureBatchTreeNode {
     constructor(readonly text : string, readonly resourceType : batch.BatchResourceType, readonly resource : any) { }
     readonly kind : AbtnKind = 'resource';
-    readonly uri : vscode.Uri = vscode.Uri.parse(`${UriScheme}://${this.resourceType}/${this.resource.id}.json`)
+    readonly uri : vscode.Uri = vscode.Uri.parse(`${UriScheme}://${this.resourceType}/${this.resource.id}.json`);
 }
 
 class ErrorNode implements AzureBatchTreeNode {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -118,7 +118,7 @@ export function makeTemplate(resource : any, resourceType : BatchResourceType) :
     // TODO: strip defaults (particularly nulls or empty objects) - we get null-stripping as a side-effect of transformProperties but shouldn't rely on this!
     const templateBody = filtered;
 
-    var template : any = {
+    let template : any = {
         parameters: { }
     };
 
@@ -132,7 +132,7 @@ export function makeTemplate(resource : any, resourceType : BatchResourceType) :
 }
 
 function withoutProperties(resource : any, properties : string[]) : any {
-    var result : any = {};
+    let result : any = {};
     for (const property in resource) {
         if (properties.indexOf(property) < 0) {
             result[property] = resource[property];
@@ -142,7 +142,7 @@ function withoutProperties(resource : any, properties : string[]) : any {
 }
 
 function transformProperties(obj : any, properties: string[], transform : (original : string | undefined) => string | undefined) : any {
-    var result : any = {};
+    let result : any = {};
     for (const property in obj) {
         const value = obj[property];
         if (value instanceof Array) {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -55,7 +55,7 @@ function parseTemplateCore(json : any) : IBatchResource {
             defaultValue : pval['defaultValue'],
             allowedValues : pval['allowedValues'],
             metadata : <IBatchTemplateParameterMetadata>(pval['metadata']),
-        })
+        });
     }
 
     return { isTemplate: true, templateValidationFailure: '', parameters: parameters };
@@ -84,7 +84,7 @@ function parseParametersCore(json : any) : IParameterValue[] {
         parameters.push({
             name : key,
             value : json[key]
-        })
+        });
     }
 
     return parameters;
@@ -126,7 +126,7 @@ export function makeTemplate(resource : any, resourceType : BatchResourceType) :
         type: templateResourceType(resourceType),
         apiVersion: '2017-05-01',
         properties: templateBody
-    }
+    };
 
     return template;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -355,7 +355,7 @@ export async function convertToParameterCore(document: vscode.TextDocument, sele
         type: propertyType,
         defaultValue: propertyValue,
         metadata: { description: `Value for ${property.containerName}.${property.name}` }
-    }
+    };
 
     const insertParamEdit = textmodels.getTemplateParameterInsertion(jsonSymbols, property.name, newParameterDefn);
 
@@ -399,7 +399,7 @@ function getParameterTypeName(value : any) : string {
 }
 
 async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
-    const document = await vscode.workspace.openTextDocument(node.uri)
+    const document = await vscode.workspace.openTextDocument(node.uri);
     vscode.window.showTextDocument(document);
 }
 
@@ -413,7 +413,7 @@ async function viewnodeGetAsTemplate(node : azurebatchtree.AzureBatchTreeNode) {
 }
 
 interface AllowedValueQuickPickItem extends vscode.QuickPickItem {
-    value : any
+    value : any;
 }
 
 interface ITempFileInfo {

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,7 @@
 		"no-unused-variable": true,
 		"curly": true,
 		"class-name": true,
-		"semicolon": ["always"],
+		"semicolon": [true, "always"],
 		"triple-equals": true
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
 		"no-unused-expression": true,
 		"no-duplicate-variable": true,
 		"no-unused-variable": true,
+		"no-var-keyword": true,
 		"curly": true,
 		"class-name": true,
 		"semicolon": [true, "always"],


### PR DESCRIPTION
Turned on TypeScript linter options to enforce semicolons and disallow `var`, and fixed resulting warnings.