### PR TITLE
Minor tidying, refactoring and error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,18 +56,18 @@
         "title": "Convert to Batch Template Parameter",
         "category": "Azure"
       },
-			{
-				"command": "azure.batch.get",
-				"title": "Get"
-			},
-			{
-				"command": "azure.batch.getAsTemplate",
-				"title": "Get as Template"
-			},
-			{
-				"command": "azure.batch.refresh",
-				"title": "Refresh"
-			}
+      {
+        "command": "azure.batch.get",
+        "title": "Get"
+      },
+      {
+        "command": "azure.batch.getAsTemplate",
+        "title": "Get as Template"
+      },
+      {
+        "command": "azure.batch.refresh",
+        "title": "Refresh"
+      }
     ],
     "snippets": [
       {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,14 @@
         "category": "Azure"
       },
       {
-        "command": "azure.batch.get",
-        "title": "Get"
+        "command": "azure.batch.getBatchResource",
+        "title": "Get Batch Resource",
+        "category": "Azure"
       },
       {
-        "command": "azure.batch.getAsTemplate",
-        "title": "Get as Template"
+        "command": "azure.batch.getBatchResourceAsTemplate",
+        "title": "Get Batch Resource as Template",
+        "category": "Azure"
       },
       {
         "command": "azure.batch.refresh",
@@ -97,11 +99,11 @@
       ],
       "view/item/context": [
         {
-          "command": "azure.batch.get",
+          "command": "azure.batch.getBatchResource",
           "when": "view == azure.batch.explorer && viewItem == azure.batch.resource"
         },
         {
-          "command": "azure.batch.getAsTemplate",
+          "command": "azure.batch.getBatchResourceAsTemplate",
           "when": "view == azure.batch.explorer && viewItem == azure.batch.resource"
         }
       ]

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -91,7 +91,7 @@ function parseParametersCore(json : any) : IParameterValue[] {
 }
 
 export async function listResources(shellExec : (command : string) => Promise<IShellExecResult>, resourceType : BatchResourceType) : Promise<IBatchResourceContent[] | ICommandError> {
-    const command = `az batch ${resourceType} list`;
+    const command = `az batch ${resourceType} list -ojson`;
     const result = await shellExec(command);
     if (result.exitCode === 0) {
         const raw : any[] = JSON.parse(result.output);
@@ -102,7 +102,7 @@ export async function listResources(shellExec : (command : string) => Promise<IS
 }
 
 export async function getResource(shellExec : (command : string) => Promise<IShellExecResult>, resourceType : BatchResourceType, id : string) : Promise<IBatchResourceContent | ICommandError> {
-    const command = `az batch ${resourceType} show --${resourceType}-id ${id}`;
+    const command = `az batch ${resourceType} show --${resourceType}-id ${id} -ojson`;
     const result = await shellExec(command);
     if (result.exitCode === 0) {
         const raw = JSON.parse(result.output);

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -91,7 +91,6 @@ function parseParametersCore(json : any) : IParameterValue[] {
 }
 
 export async function listResources(shellExec : (command : string) => Promise<IShellExecResult>, resourceType : BatchResourceType) : Promise<IBatchResourceContent[] | ICommandError> {
-    //const command = `az batch ${resourceType} list --query [*].{id:id,displayName:displayName}`;  // the problem is we are going to want to stringify the resource JSON and that means we need to download it - or do a second call
     const command = `az batch ${resourceType} list`;
     const result = await shellExec(command);
     if (result.exitCode === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -393,6 +393,11 @@ function getParameterTypeName(value : any) : string {
 }
 
 async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
+    if (!node) {
+        // TODO: handle this more politely
+        vscode.window.showErrorMessage("This command is used only from the Azure Batch explorer.")
+        return;
+    }
     if (azurebatchtree.isResourceNode(node)) {
         const filename = node.resourceId + `.${node.resourceType}.json`;
         createFile(filename, JSON.stringify(node.resource, null, 2));
@@ -400,6 +405,11 @@ async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
 }
 
 async function viewnodeGetAsTemplate(node : azurebatchtree.AzureBatchTreeNode) {
+    if (!node) {
+        // TODO: handle this more politely
+        vscode.window.showErrorMessage("This command is used only from the Azure Batch explorer.")
+        return;
+    }
     if (azurebatchtree.isResourceNode(node)) {
         createTemplateFile(node.resourceType, node.resource, node.resourceId);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -395,7 +395,7 @@ function getParameterTypeName(value : any) : string {
 async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
     if (!node) {
         // TODO: handle this more politely
-        vscode.window.showErrorMessage("This command is used only from the Azure Batch explorer.")
+        vscode.window.showErrorMessage("This command may be used only from the Azure Batch explorer.")
         return;
     }
     if (azurebatchtree.isResourceNode(node)) {
@@ -407,7 +407,7 @@ async function viewnodeGet(node : azurebatchtree.AzureBatchTreeNode) {
 async function viewnodeGetAsTemplate(node : azurebatchtree.AzureBatchTreeNode) {
     if (!node) {
         // TODO: handle this more politely
-        vscode.window.showErrorMessage("This command is used only from the Azure Batch explorer.")
+        vscode.window.showErrorMessage("This command may be used only from the Azure Batch explorer.")
         return;
     }
     if (azurebatchtree.isResourceNode(node)) {


### PR DESCRIPTION
Bit of a grab bag:

* Fixed tabs/spaces issue
* Removed a TODO that I had determined wasn't worth doing
* Refactored explorer selection to be less clever but saner and faster
* Added (crude) error handling if explorer commands were invoked from the palette
* Addressed potential issue if user's Azure CLI settings defaulted to non-JSON output